### PR TITLE
feat: state machine to create user canisters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: install ic-wasm
         run: |
-          wget https://github.com/dfinity/ic-wasm/releases/download/0.8.1/ic-wasm-linux64 -O /usr/local/bin/ic-wasm
+          wget https://github.com/dfinity/ic-wasm/releases/download/0.9.3/ic-wasm-linux64 -O /usr/local/bin/ic-wasm
           chmod +x /usr/local/bin/ic-wasm
 
       - name: install candid-extractor

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,13 +53,13 @@ jobs:
           toolchain: nightly
           components: rustfmt
 
-      - name: check rust code style
-        run: |
-          just check_code
-
       - name: build canisters
         run: |
           just build_all_canisters
+
+      - name: check rust code style
+        run: |
+          just check_code
 
       - name: test
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,14 +19,14 @@ checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "ahash"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
  "once_cell",
  "version_check",
- "zerocopy 0.7.35",
+ "zerocopy",
 ]
 
 [[package]]
@@ -86,19 +86,6 @@ dependencies = [
  "concurrent-queue",
  "event-listener 2.5.3",
  "futures-core",
-]
-
-[[package]]
-name = "async-compression"
-version = "0.4.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b37fc50485c4f3f736a4fb14199f6d5f5ba008d7f28fe710306c92780f004c07"
-dependencies = [
- "flate2",
- "futures-core",
- "memchr",
- "pin-project-lite",
- "tokio",
 ]
 
 [[package]]
@@ -174,9 +161,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.74"
+version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
+checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
 dependencies = [
  "addr2line",
  "cfg-if",
@@ -401,9 +388,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.20"
+version = "1.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04da6a0d40b948dfc4fa8f5bbf402b0fc1a64a28dbf7d12ffd683550f2c1b63a"
+checksum = "8691782945451c1c383942c4874dbe63814f61cb57ef773cda2972682b7bb3c0"
 dependencies = [
  "shlex",
 ]
@@ -705,15 +692,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs"
-version = "5.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -721,18 +699,6 @@ checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
  "cfg-if",
  "dirs-sys-next",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
-dependencies = [
- "libc",
- "option-ext",
- "redox_users",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -843,6 +809,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -868,6 +844,12 @@ dependencies = [
  "event-listener 5.4.0",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ff"
@@ -1000,12 +982,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "garcon"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83fb8961dcd3c26123863998521ae4d07e5e5aa8fb50b503380448f2e0ea069"
-
-[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1062,9 +1038,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75249d144030531f8dee69fe9cea04d3edf809a017ae445e2abdff6629e86633"
+checksum = "a9421a676d1b147b16b82c9225157dc629087ef8ec4d5e2960f9437a90dac0a5"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1123,9 +1099,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
 
 [[package]]
 name = "heck"
@@ -1238,7 +1214,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -1259,54 +1235,6 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "ic-agent"
-version = "0.39.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "820d65a05258f2fdff326c65561b1ddc7ec54e5d43a4b1203b25eb83075c83d4"
-dependencies = [
- "arc-swap",
- "async-channel",
- "async-lock",
- "async-trait",
- "async-watch",
- "backoff",
- "cached",
- "candid",
- "der",
- "ecdsa",
- "ed25519-consensus",
- "elliptic-curve",
- "futures-util",
- "hex",
- "http 1.3.1",
- "http-body",
- "ic-certification 3.0.3",
- "ic-transport-types 0.39.3",
- "ic-verify-bls-signature",
- "k256",
- "leb128",
- "p256",
- "pem",
- "pkcs8",
- "rand 0.8.5",
- "rangemap",
- "reqwest",
- "sec1",
- "serde",
- "serde_bytes",
- "serde_cbor",
- "serde_repr",
- "sha2 0.10.8",
- "simple_asn1",
- "stop-token",
- "thiserror 2.0.12",
- "time",
- "tokio",
- "tower-service",
- "url",
 ]
 
 [[package]]
@@ -1347,7 +1275,7 @@ dependencies = [
  "serde_bytes",
  "serde_cbor",
  "serde_repr",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "simple_asn1",
  "stop-token",
  "thiserror 2.0.12",
@@ -1479,7 +1407,7 @@ dependencies = [
  "hex",
  "serde",
  "serde_bytes",
- "sha2 0.10.8",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -1491,15 +1419,7 @@ dependencies = [
  "hex",
  "serde",
  "serde_bytes",
- "sha2 0.10.8",
-]
-
-[[package]]
-name = "ic-crypto-getrandom-for-wasm"
-version = "0.24.0"
-source = "git+https://github.com/bitfinity-network/canister-sdk?tag=v0.24.x#99ec2f7697e601d3d37193ffbe1f1b696e8d0c88"
-dependencies = [
- "getrandom 0.2.16",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -1511,25 +1431,6 @@ dependencies = [
  "serde",
  "strum",
  "strum_macros",
-]
-
-[[package]]
-name = "ic-exports"
-version = "0.24.0"
-source = "git+https://github.com/bitfinity-network/canister-sdk?tag=v0.24.x#99ec2f7697e601d3d37193ffbe1f1b696e8d0c88"
-dependencies = [
- "candid",
- "flate2",
- "ic-cdk 0.17.1",
- "ic-cdk-macros 0.17.1",
- "ic-cdk-timers 0.11.0",
- "ic-crypto-getrandom-for-wasm",
- "ic-kit",
- "log",
- "pocket-ic",
- "reqwest",
- "serde",
- "tokio",
 ]
 
 [[package]]
@@ -1547,19 +1448,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ic-kit"
-version = "0.24.0"
-source = "git+https://github.com/bitfinity-network/canister-sdk?tag=v0.24.x#99ec2f7697e601d3d37193ffbe1f1b696e8d0c88"
-dependencies = [
- "candid",
- "futures",
- "ic-cdk 0.17.1",
- "ic-cdk-macros 0.17.1",
- "serde",
- "serde_bytes",
-]
-
-[[package]]
 name = "ic-ledger-types"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1571,7 +1459,7 @@ dependencies = [
  "ic-cdk 0.18.0",
  "serde",
  "serde_bytes",
- "sha2 0.10.8",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -1591,7 +1479,7 @@ version = "2.6.0"
 source = "git+https://github.com/dfinity/response-verification?rev=da70db93832f88ecc556ae082612aedec47d3816#da70db93832f88ecc556ae082612aedec47d3816"
 dependencies = [
  "leb128",
- "sha2 0.10.8",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -1601,21 +1489,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f5684f577e0146738cd11afed789109c4f51ba963c75823c48c1501dc53278"
 dependencies = [
  "ic_principal",
-]
-
-[[package]]
-name = "ic-test-utils"
-version = "0.24.0"
-source = "git+https://github.com/bitfinity-network/canister-sdk?tag=v0.24.x#99ec2f7697e601d3d37193ffbe1f1b696e8d0c88"
-dependencies = [
- "candid",
- "dirs",
- "garcon",
- "ic-agent 0.39.3",
- "serde",
- "serde_bytes",
- "serde_json",
- "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -1632,7 +1505,7 @@ dependencies = [
  "serde_bytes",
  "serde_cbor",
  "serde_repr",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "thiserror 2.0.12",
 ]
 
@@ -1650,7 +1523,7 @@ dependencies = [
  "serde_bytes",
  "serde_cbor",
  "serde_repr",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "thiserror 2.0.12",
 ]
 
@@ -1663,12 +1536,12 @@ dependencies = [
  "async-trait",
  "candid",
  "futures-util",
- "ic-agent 0.40.0",
+ "ic-agent",
  "once_cell",
  "semver",
  "serde",
  "serde_bytes",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "strum",
  "strum_macros",
  "thiserror 2.0.12",
@@ -1687,7 +1560,7 @@ dependencies = [
  "lazy_static",
  "pairing",
  "rand 0.8.5",
- "sha2 0.10.8",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -1726,27 +1599,28 @@ dependencies = [
  "crc32fast",
  "data-encoding",
  "serde",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "icu_collections"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
 dependencies = [
  "displaydoc",
+ "potential_utf",
  "yoke",
  "zerofrom",
  "zerovec",
 ]
 
 [[package]]
-name = "icu_locid"
-version = "1.5.0"
+name = "icu_locale_core"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1756,30 +1630,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_locid_transform"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_locid_transform_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform_data"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7515e6d781098bf9f7205ab3fc7e9709d34554ae0b21ddbcb5febfa4bc7df11d"
-
-[[package]]
 name = "icu_normalizer"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
 dependencies = [
  "displaydoc",
  "icu_collections",
@@ -1787,65 +1641,52 @@ dependencies = [
  "icu_properties",
  "icu_provider",
  "smallvec",
- "utf16_iter",
- "utf8_iter",
- "write16",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_normalizer_data"
-version = "1.5.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e8338228bdc8ab83303f16b797e177953730f601a96c25d10cb3ab0daa0cb7"
+checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
 
 [[package]]
 name = "icu_properties"
-version = "1.5.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+checksum = "2549ca8c7241c82f59c80ba2a6f415d931c5b58d24fb8412caa1a1f02c49139a"
 dependencies = [
  "displaydoc",
  "icu_collections",
- "icu_locid_transform",
+ "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
- "tinystr",
+ "potential_utf",
+ "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "1.5.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85fb8799753b75aee8d2a21d7c14d9f38921b54b3dbda10f5a3c7a7b82dba5e2"
+checksum = "8197e866e47b68f8f7d95249e172903bec06004b18b2937f1095d40a0c57de04"
 
 [[package]]
 name = "icu_provider"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
 dependencies = [
  "displaydoc",
- "icu_locid",
- "icu_provider_macros",
+ "icu_locale_core",
  "stable_deref_trait",
  "tinystr",
  "writeable",
  "yoke",
  "zerofrom",
+ "zerotrie",
  "zerovec",
-]
-
-[[package]]
-name = "icu_provider_macros"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
 ]
 
 [[package]]
@@ -1867,9 +1708,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1882,7 +1723,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.3",
 ]
 
 [[package]]
@@ -1901,13 +1742,14 @@ dependencies = [
  "anyhow",
  "candid",
  "did",
- "ic-agent 0.40.0",
- "ic-exports",
+ "flate2",
+ "ic-agent",
  "ic-ledger-types",
- "ic-test-utils",
  "ic-utils",
+ "log",
  "pocket-ic",
  "pretty_assertions",
+ "reqwest",
  "serde",
  "tokio",
 ]
@@ -1953,7 +1795,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "once_cell",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "signature",
 ]
 
@@ -2017,10 +1859,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "litemap"
-version = "0.7.5"
+name = "linux-raw-sys"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+
+[[package]]
+name = "litemap"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "lock_api"
@@ -2222,12 +2070,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
-name = "option-ext"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
 name = "orbit-essentials"
 version = "0.2.0"
 source = "git+https://github.com/dfinity/orbit?tag=%40orbit%2Fstation-v0.5.0#6fa186f8d99886b7cb471260cfea6575ab77ca7b"
@@ -2250,7 +2092,7 @@ dependencies = [
  "serde_bytes",
  "serde_cbor",
  "serde_json",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
  "time",
  "uuid",
@@ -2295,7 +2137,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2 0.10.8",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -2409,7 +2251,7 @@ checksum = "7f9f832470494906d1fca5329f8ab5791cc60beb230c74815dff541cbd2b5ca0"
 dependencies = [
  "once_cell",
  "pest",
- "sha2 0.10.8",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -2461,9 +2303,9 @@ dependencies = [
 
 [[package]]
 name = "pocket-ic"
-version = "7.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccd672d6b262731dccae40cb561e4c578709ea9987fbf649377d51077bf16db3"
+checksum = "1d0dee25e0f699db883fa2228b18b6e86ae874a0f538dd362aef70679ca5cc6d"
 dependencies = [
  "backoff",
  "base64 0.13.1",
@@ -2471,6 +2313,7 @@ dependencies = [
  "flate2",
  "hex",
  "ic-certification 3.0.3",
+ "ic-management-canister-types",
  "ic-transport-types 0.39.3",
  "reqwest",
  "schemars",
@@ -2478,16 +2321,26 @@ dependencies = [
  "serde_bytes",
  "serde_cbor",
  "serde_json",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "slog",
  "strum",
  "strum_macros",
+ "tempfile",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
  "wslpath",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
+dependencies = [
+ "zerovec",
 ]
 
 [[package]]
@@ -2502,7 +2355,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy 0.8.25",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2622,9 +2475,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.11"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "541d0f57c6ec747a90738a52741d3221f7960e8ac2f0ff4b1a63680e033b4ab5"
+checksum = "ee4e529991f949c5e25755532370b8af5d114acae52326361d68d47af64aa842"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -2716,9 +2569,9 @@ checksum = "f60fcc7d6849342eff22c4350c8b9a989ee8ceabc4b481253e8946b9fe83d684"
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.11"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
+checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
 dependencies = [
  "bitflags",
 ]
@@ -2784,7 +2637,6 @@ version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
 dependencies = [
- "async-compression",
  "base64 0.22.1",
  "bytes",
  "futures-channel",
@@ -2825,7 +2677,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 0.26.11",
  "windows-registry",
 ]
 
@@ -2866,10 +2718,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
-name = "rustls"
-version = "0.23.26"
+name = "rustix"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df51b5869f3a441595eac5e8ff14d486ff285f7b8c0df8770e49c3b56351f0f0"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "730944ca083c1c233a75c09f199e973ca499344a2b7ba9e755c457e86fb4a321"
 dependencies = [
  "once_cell",
  "ring",
@@ -2902,18 +2767,19 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
+checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
 dependencies = [
  "web-time",
+ "zeroize",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.1"
+version = "0.103.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fef8b8769aaccf73098557a87cd1816b4f9c7c16811c9c77142aa695c16f2c03"
+checksum = "7149975849f1abb3832b246010ef62ccc80d3a76169517ada7188252b9cfb437"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -3147,9 +3013,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -3390,13 +3256,26 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.101",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3511,9 +3390,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.7.6"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -3536,9 +3415,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.44.2"
+version = "1.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
+checksum = "2513ca694ef9ede0fb23fe71a4ee4107cb102b9dc1930f6d0fd77aae068ae165"
 dependencies = [
  "backtrace",
  "bytes",
@@ -3824,12 +3703,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
-name = "utf16_iter"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
-
-[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3997,9 +3870,18 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.9"
+version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29aad86cec885cafd03e8305fd727c418e970a521322c91688414d5b8efba16b"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.0",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2853738d1cc4f2da3a225c18ec6c3721abb31961096e9dbf5ab35fa88b19cfdb"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -4072,15 +3954,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -4095,21 +3968,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -4146,12 +4004,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -4164,12 +4016,6 @@ checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -4179,12 +4025,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4212,12 +4052,6 @@ checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -4227,12 +4061,6 @@ name = "windows_i686_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4248,12 +4076,6 @@ checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -4263,12 +4085,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -4284,9 +4100,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.7"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb8234a863ea0e8cd7284fcdd4f145233eb00fee02bbdd9861aec44e6477bc5"
+checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
 dependencies = [
  "memchr",
 ]
@@ -4301,16 +4117,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "write16"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
-
-[[package]]
 name = "writeable"
-version = "0.5.5"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
 
 [[package]]
 name = "wslpath"
@@ -4326,9 +4136,9 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
+checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -4338,9 +4148,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
+checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4350,31 +4160,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
-dependencies = [
- "zerocopy-derive 0.7.35",
-]
-
-[[package]]
-name = "zerocopy"
 version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
 dependencies = [
- "zerocopy-derive 0.8.25",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
+ "zerocopy-derive",
 ]
 
 [[package]]
@@ -4416,10 +4206,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
-name = "zerovec"
-version = "0.10.4"
+name = "zerotrie"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -4428,9 +4229,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.10.3"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1457,6 +1457,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ic-cdk-timers"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "647de2a321d15442c2a73597fd81f031af80624022f069844bf789a317889299"
+dependencies = [
+ "candid",
+ "futures",
+ "ic-cdk 0.18.0",
+ "ic0 0.24.0",
+ "serde",
+ "serde_bytes",
+ "slotmap",
+]
+
+[[package]]
 name = "ic-certification"
 version = "2.6.0"
 source = "git+https://github.com/dfinity/response-verification?rev=da70db93832f88ecc556ae082612aedec47d3816#da70db93832f88ecc556ae082612aedec47d3816"
@@ -1507,7 +1522,7 @@ dependencies = [
  "flate2",
  "ic-cdk 0.17.1",
  "ic-cdk-macros 0.17.1",
- "ic-cdk-timers",
+ "ic-cdk-timers 0.11.0",
  "ic-crypto-getrandom-for-wasm",
  "ic-kit",
  "log",
@@ -2223,7 +2238,7 @@ dependencies = [
  "getrandom 0.2.16",
  "hex",
  "ic-cdk 0.16.0",
- "ic-cdk-timers",
+ "ic-cdk-timers 0.11.0",
  "ic-certification 2.6.0",
  "ic-http-certification",
  "ic-representation-independent-hash",
@@ -2259,8 +2274,10 @@ dependencies = [
  "did",
  "ic-cdk 0.18.0",
  "ic-cdk-macros 0.18.0",
+ "ic-cdk-timers 0.12.0",
  "ic-stable-structures",
  "serde",
+ "time",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ rust-version = "1.85"
 cargo_metadata = "0.19"
 ic-cdk = "0.18"
 ic-cdk-macros = "0.18"
+ic-cdk-timers = "0.12"
 ic-stable-structures = "0.6.8"
 candid = { version = "0.10", features = ["value"] }
 candid_parser = "0.2.0-beta.4"
@@ -27,3 +28,4 @@ rand_chacha = "0.9"
 serde = "1"
 serde_bytes = "0.11"
 station-api = { git = "https://github.com/dfinity/orbit", tag = "@orbit/station-v0.5.0" }
+time = { version = "0.3", features = ["parsing"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,4 +28,4 @@ rand_chacha = "0.9"
 serde = "1"
 serde_bytes = "0.11"
 station-api = { git = "https://github.com/dfinity/orbit", tag = "@orbit/station-v0.5.0" }
-time = { version = "0.3", features = ["parsing"] }
+time = { version = "0.3", default-features = false, features = ["parsing"] }

--- a/backend/did/src/orchestrator.rs
+++ b/backend/did/src/orchestrator.rs
@@ -1,4 +1,5 @@
 mod user;
+mod user_canister;
 mod whoami;
 
 use candid::{CandidType, Principal};
@@ -7,10 +8,14 @@ use serde::{Deserialize, Serialize};
 pub use self::user::{
     GetUsersResponse, MAX_USERNAME_SIZE, PUBKEY_SIZE, PublicKey, PublicUser, SetUserResponse, User,
 };
+pub use self::user_canister::UserCanisterResponse;
 pub use self::whoami::WhoamiResponse;
 
 /// Orchestrator canister init arguments
 #[derive(Debug, CandidType, Serialize, Deserialize)]
 pub struct OrchestratorInitArgs {
+    /// UUID of the Orbit Station admin
+    pub orbit_station_admin: String,
+    /// Principal of the Orbit Station canister
     pub orbit_station: Principal,
 }

--- a/backend/did/src/orchestrator.rs
+++ b/backend/did/src/orchestrator.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 pub use self::user::{
     GetUsersResponse, MAX_USERNAME_SIZE, PUBKEY_SIZE, PublicKey, PublicUser, SetUserResponse, User,
 };
-pub use self::user_canister::UserCanisterResponse;
+pub use self::user_canister::{RetryUserCanisterCreationResponse, UserCanisterResponse};
 pub use self::whoami::WhoamiResponse;
 
 /// Orchestrator canister init arguments

--- a/backend/did/src/orchestrator/user_canister.rs
+++ b/backend/did/src/orchestrator/user_canister.rs
@@ -15,3 +15,18 @@ pub enum UserCanisterResponse {
     /// Called with an anonymous caller
     AnonymousCaller,
 }
+
+/// Response for `retry_user_canister_creation` query
+#[derive(CandidType, Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub enum RetryUserCanisterCreationResponse {
+    /// The user canister is being retried
+    Ok,
+    /// The user canister exists.
+    Created(Principal),
+    /// Creation is already in progress
+    CreationPending,
+    /// Anonymous caller
+    AnonymousCaller,
+    /// User not found - use `set_user` first to create a user
+    UserNotFound,
+}

--- a/backend/did/src/orchestrator/user_canister.rs
+++ b/backend/did/src/orchestrator/user_canister.rs
@@ -1,0 +1,17 @@
+use candid::{CandidType, Principal};
+use serde::{Deserialize, Serialize};
+
+/// Response for `user_canister` query
+#[derive(CandidType, Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub enum UserCanisterResponse {
+    /// The user canister is created and ready to use
+    Ok(Principal),
+    /// The user canister is being created
+    CreationPending,
+    /// The user canister creation failed; returns the reason
+    CreationFailed { reason: String },
+    /// The creation is not started yet
+    Uninitialized,
+    /// Called with an anonymous caller
+    AnonymousCaller,
+}

--- a/backend/orchestrator/Cargo.toml
+++ b/backend/orchestrator/Cargo.toml
@@ -13,7 +13,9 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 ic-cdk = { workspace = true }
 ic-cdk-macros = { workspace = true }
+ic-cdk-timers = { workspace = true }
 ic-stable-structures = { workspace = true }
 candid = { workspace = true }
 did = { path = "../did" }
 serde = { workspace = true }
+time = { workspace = true }

--- a/backend/orchestrator/src/canister.rs
+++ b/backend/orchestrator/src/canister.rs
@@ -65,11 +65,6 @@ impl Canister {
             return SetUserResponse::CallerHasAlreadyAUser;
         }
 
-        // start state machine to create user canister
-        if cfg!(target_family = "wasm") {
-            CreateUserStateMachine::start(Config::get_orbit_station(), caller);
-        }
-
         // Add the user to the storage and return Ok.
         UserStorage::add_user(
             caller,
@@ -78,6 +73,11 @@ impl Canister {
                 public_key,
             },
         );
+
+        // start state machine to create user canister
+        if cfg!(target_family = "wasm") {
+            CreateUserStateMachine::start(Config::get_orbit_station(), caller);
+        }
 
         SetUserResponse::Ok
     }

--- a/backend/orchestrator/src/canister.rs
+++ b/backend/orchestrator/src/canister.rs
@@ -1,10 +1,14 @@
+mod create_user;
+
 use candid::Principal;
+use create_user::CreateUserStateMachine;
 use did::orchestrator::{
     GetUsersResponse, MAX_USERNAME_SIZE, OrchestratorInitArgs, PublicKey, PublicUser,
-    SetUserResponse, User, WhoamiResponse,
+    SetUserResponse, User, UserCanisterResponse, WhoamiResponse,
 };
 
 use crate::storage::config::Config;
+use crate::storage::user_canister::{UserCanisterCreateState, UserCanisterStorage};
 use crate::storage::users::UserStorage;
 use crate::utils::msg_caller;
 
@@ -15,6 +19,7 @@ impl Canister {
     /// Initialize the canister with the given arguments.
     pub fn init(args: OrchestratorInitArgs) {
         Config::set_orbit_station(args.orbit_station);
+        Config::set_orbit_station_admin(args.orbit_station_admin);
     }
 
     /// Get the users from the storage as [`GetUsersResponse`].
@@ -60,6 +65,11 @@ impl Canister {
             return SetUserResponse::CallerHasAlreadyAUser;
         }
 
+        // start state machine to create user canister
+        if cfg!(target_family = "wasm") {
+            CreateUserStateMachine::start(Config::get_orbit_station(), caller);
+        }
+
         // Add the user to the storage and return Ok.
         UserStorage::add_user(
             caller,
@@ -75,6 +85,33 @@ impl Canister {
     /// Checks whether a given username exists in the storage.
     pub fn username_exists(username: String) -> bool {
         UserStorage::username_exists(&username)
+    }
+
+    /// Get user canister information for the current caller.
+    ///
+    /// Returns [`UserCanisterResponse::AnonymousCaller`] if the caller is anonymous.
+    /// Returns [`UserCanisterResponse::Ok`] if the user canister is created and ready to use.
+    /// Returns [`UserCanisterResponse::CreationPending`] if the user canister is being created.
+    /// Returns [`UserCanisterResponse::CreationFailed`] if the user canister creation failed.
+    pub fn user_canister() -> UserCanisterResponse {
+        let caller = msg_caller();
+        if caller == Principal::anonymous() {
+            return UserCanisterResponse::AnonymousCaller;
+        }
+
+        if let Some(canister) = UserCanisterStorage::get_user_canister(caller) {
+            return UserCanisterResponse::Ok(canister);
+        }
+
+        // otherwise check if it failed or it is pending
+        UserCanisterStorage::get_create_state(caller)
+            .map(|state| match state {
+                UserCanisterCreateState::Failed { reason } => {
+                    UserCanisterResponse::CreationFailed { reason }
+                }
+                _ => UserCanisterResponse::CreationPending,
+            })
+            .unwrap_or(UserCanisterResponse::Uninitialized)
     }
 
     /// Get [`WhoamiResponse`] for the current caller.
@@ -101,7 +138,10 @@ mod test {
     #[test]
     fn test_should_init_canister() {
         let orbit_station = Principal::from_text("rwlgt-iiaaa-aaaaa-aaaaa-cai").unwrap();
-        Canister::init(OrchestratorInitArgs { orbit_station });
+        Canister::init(OrchestratorInitArgs {
+            orbit_station,
+            orbit_station_admin: "admin".to_string(),
+        });
 
         assert_eq!(Config::get_orbit_station(), orbit_station);
     }
@@ -237,6 +277,9 @@ mod test {
 
     fn init_canister() {
         let orbit_station = Principal::from_text("rwlgt-iiaaa-aaaaa-aaaaa-cai").unwrap();
-        Canister::init(OrchestratorInitArgs { orbit_station });
+        Canister::init(OrchestratorInitArgs {
+            orbit_station,
+            orbit_station_admin: "admin".to_string(),
+        });
     }
 }

--- a/backend/orchestrator/src/canister.rs
+++ b/backend/orchestrator/src/canister.rs
@@ -4,7 +4,7 @@ use candid::Principal;
 use create_user::CreateUserStateMachine;
 use did::orchestrator::{
     GetUsersResponse, MAX_USERNAME_SIZE, OrchestratorInitArgs, PublicKey, PublicUser,
-    SetUserResponse, User, UserCanisterResponse, WhoamiResponse,
+    RetryUserCanisterCreationResponse, SetUserResponse, User, UserCanisterResponse, WhoamiResponse,
 };
 
 use crate::storage::config::Config;
@@ -40,6 +40,46 @@ impl Canister {
             .map(|(principal, user)| PublicUser::new(user, principal))
             .collect::<Vec<_>>()
             .into()
+    }
+
+    /// Retry the user canister creation for the current caller.
+    ///
+    /// Returns:
+    ///
+    /// - [`RetryUserCanisterCreationResponse::Ok`] if the user canister creation is retried.
+    /// - [`RetryUserCanisterCreationResponse::Created`] if the user canister already exists.
+    /// - [`RetryUserCanisterCreationResponse::AnonymousCaller`]: The caller is anonymous.
+    /// - [`RetryUserCanisterCreationResponse::CreationPending`]: The user canister creation is already in progress.
+    /// - [`RetryUserCanisterCreationResponse::UserNotFound`]: The user doesn't exist. In that case, the caller should call `set_user` first.
+    pub fn retry_user_canister_creation() -> RetryUserCanisterCreationResponse {
+        let caller = msg_caller();
+        if caller == Principal::anonymous() {
+            return RetryUserCanisterCreationResponse::AnonymousCaller;
+        }
+
+        // check if the user exists
+        if UserStorage::get_user(&caller).is_none() {
+            return RetryUserCanisterCreationResponse::UserNotFound;
+        }
+
+        // check if the user canister already exists
+        if let Some(canister) = UserCanisterStorage::get_user_canister(caller) {
+            return RetryUserCanisterCreationResponse::Created(canister);
+        }
+
+        // check the current state of the user canister creation
+        match UserCanisterStorage::get_create_state(caller) {
+            Some(UserCanisterCreateState::Ok { user_canister }) => {
+                RetryUserCanisterCreationResponse::Created(user_canister)
+            }
+            Some(UserCanisterCreateState::Failed { .. }) | None => {
+                if cfg!(target_family = "wasm") {
+                    CreateUserStateMachine::start(Config::get_orbit_station(), caller);
+                }
+                RetryUserCanisterCreationResponse::Ok
+            }
+            Some(_) => RetryUserCanisterCreationResponse::CreationPending,
+        }
     }
 
     /// Set a new user in the storage.
@@ -170,6 +210,99 @@ mod test {
                 ic_principal: principal,
             }])
         );
+    }
+
+    #[test]
+    fn test_should_retry_user_canister_creation() {
+        init_canister();
+
+        // let's setup a user
+        let principal = msg_caller();
+        UserStorage::add_user(
+            principal,
+            User {
+                username: "test_user".to_string(),
+                public_key: [1; 32],
+            },
+        );
+
+        // of course this won't start the state machine on test unit; let's set the state to failed
+        UserCanisterStorage::set_create_state(
+            principal,
+            UserCanisterCreateState::Failed {
+                reason: "test".to_string(),
+            },
+        );
+
+        // we can retry now :D
+        let response = Canister::retry_user_canister_creation();
+        assert_eq!(response, RetryUserCanisterCreationResponse::Ok);
+    }
+
+    #[test]
+    fn test_should_not_retry_user_canister_creation_if_user_does_not_exist() {
+        init_canister();
+
+        // let's setup another user
+        UserStorage::add_user(
+            Principal::management_canister(),
+            User {
+                username: "test_user".to_string(),
+                public_key: [1; 32],
+            },
+        );
+
+        // user does not exist
+        let response = Canister::retry_user_canister_creation();
+        assert_eq!(response, RetryUserCanisterCreationResponse::UserNotFound);
+    }
+
+    #[test]
+    fn test_should_not_retry_if_user_canister_exists() {
+        init_canister();
+
+        // let's setup a user
+        let principal = msg_caller();
+        UserStorage::add_user(
+            principal,
+            User {
+                username: "test_user".to_string(),
+                public_key: [1; 32],
+            },
+        );
+
+        // let's set the user canister
+        let user_canister = Principal::from_text("rwlgt-iiaaa-aaaaa-aaaaa-cai").unwrap();
+        UserCanisterStorage::set_user_canister(principal, user_canister);
+
+        // canister already exists
+        let response = Canister::retry_user_canister_creation();
+        assert_eq!(
+            response,
+            RetryUserCanisterCreationResponse::Created(user_canister)
+        );
+    }
+
+    #[test]
+    fn test_should_not_retry_if_pending() {
+        init_canister();
+
+        // let's setup a user
+        let principal = msg_caller();
+        UserStorage::add_user(
+            principal,
+            User {
+                username: "test_user".to_string(),
+                public_key: [1; 32],
+            },
+        );
+
+        // let's set the user canister creation state to something pending
+        UserCanisterStorage::set_create_state(principal, UserCanisterCreateState::CreateCanister);
+
+        // canister already exists
+        let response = Canister::retry_user_canister_creation();
+        assert_eq!(response, RetryUserCanisterCreationResponse::CreationPending);
     }
 
     #[test]

--- a/backend/orchestrator/src/canister/create_user.rs
+++ b/backend/orchestrator/src/canister/create_user.rs
@@ -92,7 +92,7 @@ impl CreateUserStateMachine {
             UserCanisterCreateState::Failed { .. } => return, // stop the state machine
         };
 
-        // update state in storage if variant has changed
+        // update state in storage if the variant type has changed
         if std::mem::discriminant(&new_state) != current_state_id {
             UserCanisterStorage::set_create_state(self.user, new_state.clone());
         }

--- a/backend/orchestrator/src/canister/create_user.rs
+++ b/backend/orchestrator/src/canister/create_user.rs
@@ -42,11 +42,9 @@ impl CreateUserStateMachine {
     fn tick(self, delay: Duration) {
         // run state machine
         ic_cdk_timers::set_timer(delay, move || {
-            ic_cdk::futures::in_executor_context(|| {
-                ic_cdk::futures::spawn(async move {
-                    self.run().await;
-                });
-            })
+            ic_cdk::futures::spawn(async move {
+                self.run().await;
+            });
         });
     }
 

--- a/backend/orchestrator/src/canister/create_user.rs
+++ b/backend/orchestrator/src/canister/create_user.rs
@@ -1,0 +1,353 @@
+use std::time::Duration;
+
+use candid::Principal;
+use did::orbit_station::{RequestOperation, RequestStatus, TimestampRfc3339};
+use time::OffsetDateTime;
+use time::format_description::well_known::Rfc3339;
+
+use crate::client::OrbitStationClient;
+use crate::storage::config::Config;
+use crate::storage::user_canister::{UserCanisterCreateState, UserCanisterStorage};
+use crate::utils::{datetime, trap};
+
+/// Default interval between each operation.
+const DEFAULT_INTERVAL: Duration = Duration::from_secs(10);
+/// Interval to wait for the Orbit Station to process the request.
+const ORBIT_STATION_REQUEST_INTERVAL: Duration = Duration::from_secs(60);
+/// The WASM file for the user canister.
+const USER_CANISTER_WASM: &[u8] = include_bytes!("../../../../.artifact/backend.wasm.gz");
+
+/// A service to create the user canister for a user.
+#[derive(Debug, Clone, Copy)]
+pub struct CreateUserStateMachine {
+    orbit_station: Principal,
+    user: Principal,
+}
+
+impl CreateUserStateMachine {
+    /// Creates a new instance of [`CreateUserStateMachine`] and starts it.
+    pub fn start(orbit_station: Principal, user: Principal) {
+        let state_machine = Self {
+            orbit_station,
+            user,
+        };
+
+        // Initialize the user canister creation state.
+        UserCanisterStorage::init_create_state(state_machine.user);
+
+        state_machine.tick(Duration::from_secs(1));
+    }
+
+    /// Set a timer to wait for the specified duration and then run the state machine.
+    fn tick(self, delay: Duration) {
+        // run state machine
+        ic_cdk_timers::set_timer(delay, move || {
+            ic_cdk::futures::in_executor_context(|| {
+                ic_cdk::futures::spawn(async move {
+                    self.run().await;
+                });
+            })
+        });
+    }
+
+    /// Run a step of the state machine.
+    async fn run(self) {
+        // load state from storage
+        let current_state = UserCanisterStorage::get_create_state(self.user)
+            .unwrap_or_else(|| trap("User canister creation state not found"));
+
+        let current_state_id = std::mem::discriminant(&current_state);
+
+        let new_state = match current_state {
+            UserCanisterCreateState::CreateCanister => self.create_canister().await,
+            UserCanisterCreateState::WaitForCreateCanisterSchedule { request_id, .. } => {
+                self.check_create_canister_result(request_id).await
+            }
+            UserCanisterCreateState::WaitForCreateCanisterResult { request_id, .. } => {
+                self.check_create_canister_result(request_id).await
+            }
+            UserCanisterCreateState::InstallCanister { user_canister } => {
+                self.install_canister(user_canister).await
+            }
+            UserCanisterCreateState::WaitForInstallCanisterSchedule {
+                request_id,
+                user_canister,
+                ..
+            } => {
+                self.check_install_canister_result(request_id, user_canister)
+                    .await
+            }
+            UserCanisterCreateState::WaitForInstallCanisterResult {
+                request_id,
+                user_canister,
+            } => {
+                self.check_install_canister_result(request_id, user_canister)
+                    .await
+            }
+            UserCanisterCreateState::Ok { user_canister } => {
+                self.complete(user_canister);
+
+                return; // stop the state machine
+            }
+            UserCanisterCreateState::Failed { .. } => return, // stop the state machine
+        };
+
+        // update state in storage if variant has changed
+        if std::mem::discriminant(&new_state) != current_state_id {
+            UserCanisterStorage::set_create_state(self.user, new_state.clone());
+        }
+
+        // schedule next step
+        let delay = Self::delay(&new_state);
+        self.tick(delay);
+    }
+
+    /// Sends a request to the Orbit Station canister to install the user canister.
+    async fn create_canister(&self) -> UserCanisterCreateState {
+        let orbit_station_admin = Config::get_orbit_station_admin();
+
+        match OrbitStationClient::from(self.orbit_station)
+            .create_user_canister(self.user, orbit_station_admin)
+            .await
+        {
+            Ok(Ok(request)) => UserCanisterCreateState::WaitForCreateCanisterResult {
+                request_id: request.request.id,
+            },
+            Ok(Err(e)) => UserCanisterCreateState::Failed {
+                reason: format!("failed to create canister: {e:?}"),
+            },
+            Err(err) => UserCanisterCreateState::Failed {
+                reason: format!("failed to create canister: {err}"),
+            },
+        }
+    }
+
+    /// Checks the result of the create canister request.
+    async fn check_create_canister_result(&self, request_id: String) -> UserCanisterCreateState {
+        // send request to get the request status
+        let response = match OrbitStationClient::from(self.orbit_station)
+            .get_request_status(request_id.clone())
+            .await
+        {
+            Ok(Ok(response)) => response,
+            Ok(Err(e)) => {
+                return UserCanisterCreateState::Failed {
+                    reason: format!(
+                        "failed to get request status for {request_id} (create_canister): {e:?}"
+                    ),
+                };
+            }
+            Err(err) => {
+                return UserCanisterCreateState::Failed {
+                    reason: format!(
+                        "failed to get request status for {request_id} (create_canister): {err}"
+                    ),
+                };
+            }
+        };
+
+        let status = response.request.status;
+        match status {
+            RequestStatus::Completed { .. } => {
+                // operation is successful; get canister id
+                let op = match response.request.operation {
+                    RequestOperation::CreateExternalCanister(op) => op,
+                    _ => trap(format!(
+                        "unexpected operation type: {:?}",
+                        response.request.operation
+                    )),
+                };
+
+                match op.canister_id {
+                    Some(user_canister) => {
+                        UserCanisterCreateState::InstallCanister { user_canister }
+                    }
+                    None => UserCanisterCreateState::Failed {
+                        reason: "Canister ID not found after creation".to_string(),
+                    },
+                }
+            }
+            RequestStatus::Failed { reason } => UserCanisterCreateState::Failed {
+                reason: format!("failed to create canister: {}", reason.unwrap_or_default()),
+            },
+            RequestStatus::Rejected => UserCanisterCreateState::Failed {
+                reason: "create_canister request rejected".to_string(),
+            },
+            RequestStatus::Cancelled { reason } => UserCanisterCreateState::Failed {
+                reason: format!(
+                    "create_canister request cancelled: {}",
+                    reason.unwrap_or_default()
+                ),
+            },
+            RequestStatus::Scheduled { scheduled_at } => {
+                // operation is scheduled; update state
+                UserCanisterCreateState::WaitForCreateCanisterSchedule {
+                    request_id,
+                    scheduled_at,
+                }
+            }
+            RequestStatus::Approved | RequestStatus::Created | RequestStatus::Processing { .. } => {
+                // operation is in progress; update state
+                UserCanisterCreateState::WaitForCreateCanisterResult { request_id }
+            }
+        }
+    }
+
+    /// Installs the user canister by sending a request to the Orbit Station canister.
+    async fn install_canister(&self, user_canister: Principal) -> UserCanisterCreateState {
+        match OrbitStationClient::from(self.orbit_station)
+            .install_user_canister(user_canister, self.user, USER_CANISTER_WASM)
+            .await
+        {
+            Ok(Ok(request)) => UserCanisterCreateState::WaitForInstallCanisterResult {
+                request_id: request.request.id,
+                user_canister,
+            },
+            Ok(Err(e)) => UserCanisterCreateState::Failed {
+                reason: format!("failed to install canister: {e:?}"),
+            },
+            Err(err) => UserCanisterCreateState::Failed {
+                reason: format!("failed to install canister: {err}"),
+            },
+        }
+    }
+
+    /// Checks the result of the install canister request.
+    async fn check_install_canister_result(
+        &self,
+        request_id: String,
+        user_canister: Principal,
+    ) -> UserCanisterCreateState {
+        // send request to get the request status
+        let response = match OrbitStationClient::from(self.orbit_station)
+            .get_request_status(request_id.clone())
+            .await
+        {
+            Ok(Ok(response)) => response,
+            Ok(Err(e)) => {
+                return UserCanisterCreateState::Failed {
+                    reason: format!(
+                        "failed to get request status for {request_id} (install_canister): {e:?}"
+                    ),
+                };
+            }
+            Err(err) => {
+                return UserCanisterCreateState::Failed {
+                    reason: format!(
+                        "failed to get request status for {request_id} (install_canister): {err}"
+                    ),
+                };
+            }
+        };
+
+        let status = response.request.status;
+        match status {
+            RequestStatus::Completed { .. } => UserCanisterCreateState::Ok { user_canister },
+            RequestStatus::Failed { reason } => UserCanisterCreateState::Failed {
+                reason: format!("failed to install canister: {}", reason.unwrap_or_default()),
+            },
+            RequestStatus::Rejected => UserCanisterCreateState::Failed {
+                reason: "install_canister request rejected".to_string(),
+            },
+            RequestStatus::Cancelled { reason } => UserCanisterCreateState::Failed {
+                reason: format!(
+                    "install_canister request cancelled: {}",
+                    reason.unwrap_or_default()
+                ),
+            },
+            RequestStatus::Scheduled { scheduled_at } => {
+                // operation is scheduled; update state
+                UserCanisterCreateState::WaitForInstallCanisterSchedule {
+                    request_id,
+                    scheduled_at,
+                    user_canister,
+                }
+            }
+            RequestStatus::Approved | RequestStatus::Created | RequestStatus::Processing { .. } => {
+                // operation is in progress; update state
+                UserCanisterCreateState::WaitForInstallCanisterResult {
+                    request_id,
+                    user_canister,
+                }
+            }
+        }
+    }
+
+    /// Complete user canister creation by setting the user canister ID in storage.
+    fn complete(&self, user_canister: Principal) {
+        UserCanisterStorage::set_user_canister(self.user, user_canister);
+    }
+
+    /// Get interval to sleep for the next operation [`UserCanisterCreateState`].
+    /// Returns [`Duration`].
+    fn delay(op: &UserCanisterCreateState) -> Duration {
+        match op {
+            UserCanisterCreateState::CreateCanister => DEFAULT_INTERVAL,
+            UserCanisterCreateState::WaitForCreateCanisterSchedule { scheduled_at, .. } => {
+                Self::scheduled_at_time_diff(datetime(), scheduled_at)
+            }
+            UserCanisterCreateState::WaitForCreateCanisterResult { .. } => {
+                ORBIT_STATION_REQUEST_INTERVAL
+            }
+            UserCanisterCreateState::InstallCanister { .. } => DEFAULT_INTERVAL,
+            UserCanisterCreateState::WaitForInstallCanisterSchedule { scheduled_at, .. } => {
+                Self::scheduled_at_time_diff(datetime(), scheduled_at)
+            }
+            UserCanisterCreateState::WaitForInstallCanisterResult { .. } => {
+                ORBIT_STATION_REQUEST_INTERVAL
+            }
+            UserCanisterCreateState::Ok { .. } => Duration::ZERO,
+            UserCanisterCreateState::Failed { .. } => Duration::ZERO,
+        }
+    }
+
+    /// Get the time difference between the current time and the scheduled time.
+    ///
+    /// If the scheduled time is in the past, return [`DEFAULT_INTERVAL`].
+    fn scheduled_at_time_diff(date: OffsetDateTime, scheduled_at: &TimestampRfc3339) -> Duration {
+        let scheduled_at = OffsetDateTime::parse(scheduled_at, &Rfc3339)
+            .unwrap_or_else(|_| trap("Failed to parse scheduled_at"));
+
+        (scheduled_at.unix_timestamp() as u64)
+            .checked_sub(date.unix_timestamp() as u64)
+            .map(Duration::from_secs)
+            .unwrap_or(DEFAULT_INTERVAL)
+    }
+}
+
+#[cfg(test)]
+mod test {
+
+    use time::{Date, Time};
+
+    use super::*;
+
+    #[test]
+    fn test_should_return_schedule_diff_in_the_future() {
+        let test_date = OffsetDateTime::new_utc(
+            Date::from_calendar_date(2021, time::Month::May, 6).unwrap(),
+            Time::from_hms(19, 10, 8).unwrap(),
+        );
+
+        let scheduled_at = "2021-05-06T19:17:10.000000031Z".to_string();
+
+        let diff = CreateUserStateMachine::scheduled_at_time_diff(test_date, &scheduled_at);
+
+        // diff is 7 minutes and 2 seconds
+        assert_eq!(diff.as_secs(), 7 * 60 + 2);
+    }
+
+    #[test]
+    fn test_should_return_schedule_diff_if_in_the_past() {
+        let test_date = OffsetDateTime::new_utc(
+            Date::from_calendar_date(2024, time::Month::May, 6).unwrap(),
+            Time::from_hms(19, 10, 8).unwrap(),
+        );
+
+        let scheduled_at = "2021-05-06T19:17:10.000000031Z".to_string();
+
+        let diff = CreateUserStateMachine::scheduled_at_time_diff(test_date, &scheduled_at);
+
+        assert_eq!(diff, DEFAULT_INTERVAL);
+    }
+}

--- a/backend/orchestrator/src/client.rs
+++ b/backend/orchestrator/src/client.rs
@@ -1,0 +1,3 @@
+mod orbit_station;
+
+pub use self::orbit_station::OrbitStationClient;

--- a/backend/orchestrator/src/client/orbit_station.rs
+++ b/backend/orchestrator/src/client/orbit_station.rs
@@ -1,0 +1,139 @@
+use candid::Principal;
+use did::orbit_station::{
+    Allow, AuthScope, CanisterInstallMode, ChangeExternalCanisterOperationInput,
+    CreateExternalCanisterOperationInput, CreateExternalCanisterOperationKind,
+    CreateExternalCanisterOperationKindCreateNew, CreateRequestInput, CreateRequestResult,
+    ExternalCanisterCallPermission, ExternalCanisterMetadata, ExternalCanisterPermissions,
+    ExternalCanisterRequestPoliciesCreateInput, GetRequestInput, GetRequestResult,
+    RequestExecutionSchedule, RequestOperationInput, ValidationMethodResourceTarget,
+};
+use ic_cdk::call::{Call, CallResult, Error as CallError};
+
+/// Client for the Orbit Station canister.
+pub struct OrbitStationClient {
+    principal: Principal,
+}
+
+impl From<Principal> for OrbitStationClient {
+    fn from(principal: Principal) -> Self {
+        OrbitStationClient { principal }
+    }
+}
+
+impl OrbitStationClient {
+    /// Send a request to the Orbit Station canister to get the status of a request by its ID.
+    ///
+    /// Returns [`GetRequestResult`] containing the status of the request.
+    pub async fn get_request_status(&self, request_id: String) -> CallResult<GetRequestResult> {
+        let request = GetRequestInput {
+            request_id,
+            with_full_info: None,
+        };
+
+        Call::unbounded_wait(self.principal, "get_request")
+            .with_arg(request)
+            .await?
+            .candid()
+            .map_err(CallError::from)
+    }
+
+    /// Send a request to the Orbit Station canister to create the user canister.
+    pub async fn create_user_canister(
+        &self,
+        user: Principal,
+        admin: String,
+    ) -> CallResult<CreateRequestResult> {
+        let request = CreateRequestInput {
+            title: Some(format!("create user canister for user {user}")),
+            summary: None,
+            execution_plan: Some(RequestExecutionSchedule::Immediate),
+            expiration_dt: None,
+            operation: RequestOperationInput::CreateExternalCanister(
+                CreateExternalCanisterOperationInput {
+                    permissions: ExternalCanisterPermissions {
+                        calls: vec![ExternalCanisterCallPermission {
+                            execution_method: "set_state".to_string(),
+                            allow: Allow {
+                                users: vec![admin.clone()],
+                                user_groups: vec![],
+                                auth_scope: AuthScope::Authenticated,
+                            },
+                            validation_method: ValidationMethodResourceTarget::No,
+                        }],
+                        read: Allow {
+                            users: vec![admin.clone()],
+                            user_groups: vec![],
+                            auth_scope: AuthScope::Authenticated,
+                        },
+                        change: Allow {
+                            users: vec![admin.clone()],
+                            user_groups: vec![],
+                            auth_scope: AuthScope::Authenticated,
+                        },
+                    },
+                    metadata: Some(vec![
+                        ExternalCanisterMetadata {
+                            key: "name".to_string(),
+                            value: "user canister".to_string(),
+                        },
+                        ExternalCanisterMetadata {
+                            key: "owner".to_string(),
+                            value: user.to_text(),
+                        },
+                    ]),
+                    kind: CreateExternalCanisterOperationKind::CreateNew(
+                        CreateExternalCanisterOperationKindCreateNew {
+                            initial_cycles: Some(2_000_000_000_000),
+                            subnet_selection: None,
+                        },
+                    ),
+                    name: "user_canister".to_string(),
+                    labels: None,
+                    description: Some(format!("ic-docutrack user canister for {user}")),
+                    request_policies: ExternalCanisterRequestPoliciesCreateInput {
+                        calls: vec![],
+                        change: vec![],
+                    },
+                },
+            ),
+        };
+
+        Call::unbounded_wait(self.principal, "create_request")
+            .with_arg(request)
+            .await?
+            .candid()
+            .map_err(CallError::from)
+    }
+
+    /// Install user canister with the given `wasm` module.
+    pub async fn install_user_canister(
+        &self,
+        canister_id: Principal,
+        owner: Principal,
+        wasm: &[u8],
+    ) -> CallResult<CreateRequestResult> {
+        let request = CreateRequestInput {
+            title: Some(format!("install user canister for user {owner}")),
+            summary: Some(format!(
+                "install user canister {canister_id} for user {owner}"
+            )),
+            execution_plan: Some(RequestExecutionSchedule::Immediate),
+            expiration_dt: None,
+            operation: RequestOperationInput::ChangeExternalCanister(
+                ChangeExternalCanisterOperationInput {
+                    canister_id,
+                    arg: None,
+                    module_extra_chunks: None,
+                    mode: CanisterInstallMode::Install,
+                    module: wasm.to_vec().into(),
+                },
+            ),
+        };
+
+        Call::unbounded_wait(self.principal, "create_request")
+            .with_arg(request)
+            .await?
+            .candid()
+            .map_err(CallError::from)
+    }
+}

--- a/backend/orchestrator/src/lib.rs
+++ b/backend/orchestrator/src/lib.rs
@@ -1,10 +1,12 @@
 mod canister;
+mod client;
 mod storage;
 mod utils;
 
 use candid::Principal;
 use did::orchestrator::{
-    GetUsersResponse, OrchestratorInitArgs, PublicKey, SetUserResponse, WhoamiResponse,
+    GetUsersResponse, OrchestratorInitArgs, PublicKey, SetUserResponse, UserCanisterResponse,
+    WhoamiResponse,
 };
 use ic_cdk_macros::{init, query, update};
 
@@ -34,6 +36,11 @@ pub fn set_user(username: String, public_key: PublicKey) -> SetUserResponse {
 #[query]
 pub fn username_exists(username: String) -> bool {
     Canister::username_exists(username)
+}
+
+#[query]
+pub fn user_canister() -> UserCanisterResponse {
+    Canister::user_canister()
 }
 
 #[query]

--- a/backend/orchestrator/src/lib.rs
+++ b/backend/orchestrator/src/lib.rs
@@ -5,8 +5,8 @@ mod utils;
 
 use candid::Principal;
 use did::orchestrator::{
-    GetUsersResponse, OrchestratorInitArgs, PublicKey, SetUserResponse, UserCanisterResponse,
-    WhoamiResponse,
+    GetUsersResponse, OrchestratorInitArgs, PublicKey, RetryUserCanisterCreationResponse,
+    SetUserResponse, UserCanisterResponse, WhoamiResponse,
 };
 use ic_cdk_macros::{init, query, update};
 
@@ -26,6 +26,11 @@ pub fn get_users() -> GetUsersResponse {
 #[query]
 pub fn orbit_station() -> Principal {
     Config::get_orbit_station()
+}
+
+#[update]
+pub fn retry_user_canister_creation() -> RetryUserCanisterCreationResponse {
+    Canister::retry_user_canister_creation()
 }
 
 #[update]

--- a/backend/orchestrator/src/storage.rs
+++ b/backend/orchestrator/src/storage.rs
@@ -1,4 +1,5 @@
 pub mod config;
+pub mod user_canister;
 pub mod users;
 
 mod memory;

--- a/backend/orchestrator/src/storage/config.rs
+++ b/backend/orchestrator/src/storage/config.rs
@@ -5,12 +5,18 @@ use did::StorablePrincipal;
 use ic_stable_structures::memory_manager::VirtualMemory;
 use ic_stable_structures::{DefaultMemoryImpl, StableCell};
 
-use super::memory::{MEMORY_MANAGER, ORBIT_STATION_MEMORY_ID};
+use super::memory::{MEMORY_MANAGER, ORBIT_STATION_ADMIN_MEMORY_ID, ORBIT_STATION_MEMORY_ID};
+use crate::utils::trap;
 
 thread_local! {
     /// Orbit station
     static ORBIT_STATION: RefCell<StableCell<StorablePrincipal, VirtualMemory<DefaultMemoryImpl>>> =
         RefCell::new(StableCell::new(MEMORY_MANAGER.with(|mm| mm.get(ORBIT_STATION_MEMORY_ID)), Principal::anonymous().into()).unwrap()
+    );
+
+    /// Orbit station admin
+    static ORBIT_STATION_ADMIN: RefCell<StableCell<String, VirtualMemory<DefaultMemoryImpl>>> =
+        RefCell::new(StableCell::new(MEMORY_MANAGER.with(|mm| mm.get(ORBIT_STATION_ADMIN_MEMORY_ID)), String::default()).unwrap()
     );
 }
 
@@ -26,7 +32,19 @@ impl Config {
     /// Set the orbit station [`Principal`]
     pub fn set_orbit_station(principal: Principal) {
         if let Err(err) = ORBIT_STATION.with_borrow_mut(|cell| cell.set(principal.into())) {
-            ic_cdk::trap(format!("Failed to set orbit station: {:?}", err));
+            trap(format!("Failed to set orbit station: {:?}", err));
+        }
+    }
+
+    /// Get the orbit station admin
+    pub fn get_orbit_station_admin() -> String {
+        ORBIT_STATION_ADMIN.with_borrow(|cell| cell.get().clone())
+    }
+
+    /// Set the orbit station admin
+    pub fn set_orbit_station_admin(admin: String) {
+        if let Err(err) = ORBIT_STATION_ADMIN.with_borrow_mut(|cell| cell.set(admin)) {
+            trap(format!("Failed to set orbit station admin: {:?}", err));
         }
     }
 }
@@ -40,5 +58,12 @@ mod test {
         let principal = Principal::from_slice(&[1; 29]);
         Config::set_orbit_station(principal);
         assert_eq!(Config::get_orbit_station(), principal);
+    }
+
+    #[test]
+    fn test_orbit_station_admin() {
+        let admin = "admin".to_string();
+        Config::set_orbit_station_admin(admin.clone());
+        assert_eq!(Config::get_orbit_station_admin(), admin);
     }
 }

--- a/backend/orchestrator/src/storage/memory.rs
+++ b/backend/orchestrator/src/storage/memory.rs
@@ -2,9 +2,13 @@ use ic_stable_structures::DefaultMemoryImpl;
 use ic_stable_structures::memory_manager::{MemoryId, MemoryManager as IcMemoryManager};
 
 pub const ORBIT_STATION_MEMORY_ID: MemoryId = MemoryId::new(1);
+pub const ORBIT_STATION_ADMIN_MEMORY_ID: MemoryId = MemoryId::new(2);
 
 pub const USER_STORAGE_MEMORY_ID: MemoryId = MemoryId::new(10);
 pub const USERNAMES_MEMORY_ID: MemoryId = MemoryId::new(11);
+
+pub const USER_CANISTERS_MEMORY_ID: MemoryId = MemoryId::new(20);
+pub const USER_CANISTER_CREATE_STATES_MEMORY_ID: MemoryId = MemoryId::new(21);
 
 thread_local! {
     /// Memory manager

--- a/backend/orchestrator/src/storage/user_canister.rs
+++ b/backend/orchestrator/src/storage/user_canister.rs
@@ -49,9 +49,15 @@ impl UserCanisterStorage {
     }
 
     /// Set the user canister for a certain user.
+    ///
+    /// Setting the user canister will remove the current user creation state.
     pub fn set_user_canister(principal: Principal, user_canister: Principal) {
         USER_CANISTERS.with_borrow_mut(|canisters| {
             canisters.insert(principal.into(), user_canister.into());
+        });
+
+        USER_CANISTER_CREATE_STATES.with_borrow_mut(|states| {
+            states.remove(&StorablePrincipal::from(principal));
         });
     }
 
@@ -111,5 +117,7 @@ mod test {
             UserCanisterStorage::get_user_canister(principal),
             Some(user_canister)
         );
+
+        assert_eq!(UserCanisterStorage::get_create_state(principal), None);
     }
 }

--- a/backend/orchestrator/src/storage/user_canister.rs
+++ b/backend/orchestrator/src/storage/user_canister.rs
@@ -1,0 +1,115 @@
+mod create_state;
+
+use std::cell::RefCell;
+
+use candid::Principal;
+use did::StorablePrincipal;
+use ic_stable_structures::memory_manager::VirtualMemory;
+use ic_stable_structures::{DefaultMemoryImpl, StableBTreeMap};
+
+pub use self::create_state::UserCanisterCreateState;
+use crate::storage::memory::{
+    MEMORY_MANAGER, USER_CANISTER_CREATE_STATES_MEMORY_ID, USER_CANISTERS_MEMORY_ID,
+};
+
+thread_local! {
+    /// User canisters
+    static USER_CANISTERS: RefCell<StableBTreeMap<StorablePrincipal, StorablePrincipal, VirtualMemory<DefaultMemoryImpl>>> =
+        RefCell::new(StableBTreeMap::new(MEMORY_MANAGER.with(|mm| mm.get(USER_CANISTERS_MEMORY_ID)))
+    );
+
+    /// Users storage map
+    static USER_CANISTER_CREATE_STATES: RefCell<StableBTreeMap<StorablePrincipal, UserCanisterCreateState, VirtualMemory<DefaultMemoryImpl>>> =
+        RefCell::new(StableBTreeMap::new(MEMORY_MANAGER.with(|mm| mm.get(USER_CANISTER_CREATE_STATES_MEMORY_ID)))
+    );
+}
+
+/// User canister storage to access user canisters and their create states
+pub struct UserCanisterStorage;
+
+impl UserCanisterStorage {
+    /// Initialize a user canister creation.
+    pub fn init_create_state(principal: Principal) {
+        USER_CANISTER_CREATE_STATES.with_borrow_mut(|states| {
+            states.insert(principal.into(), UserCanisterCreateState::CreateCanister)
+        });
+    }
+
+    /// Get the [`UserCanisterCreateState`] for a certain user.
+    pub fn get_create_state(principal: Principal) -> Option<UserCanisterCreateState> {
+        USER_CANISTER_CREATE_STATES
+            .with_borrow(|states| states.get(&StorablePrincipal::from(principal)).clone())
+    }
+
+    /// Update the [`UserCanisterCreateState`] for a certain user.
+    pub fn set_create_state(principal: Principal, state: UserCanisterCreateState) {
+        USER_CANISTER_CREATE_STATES.with_borrow_mut(|states| {
+            states.insert(principal.into(), state);
+        });
+    }
+
+    /// Set the user canister for a certain user.
+    pub fn set_user_canister(principal: Principal, user_canister: Principal) {
+        USER_CANISTERS.with_borrow_mut(|canisters| {
+            canisters.insert(principal.into(), user_canister.into());
+        });
+    }
+
+    /// Get the user canister for a certain user.
+    pub fn get_user_canister(principal: Principal) -> Option<Principal> {
+        USER_CANISTERS
+            .with_borrow(|canisters| canisters.get(&StorablePrincipal::from(principal)))
+            .map(|p| p.0)
+    }
+}
+
+#[cfg(test)]
+mod test {
+
+    use super::*;
+
+    #[test]
+    fn test_should_init_create_state() {
+        let principal = Principal::from_text("rwlgt-iiaaa-aaaaa-aaaaa-cai").unwrap();
+        UserCanisterStorage::init_create_state(principal);
+
+        assert_eq!(
+            UserCanisterStorage::get_create_state(principal),
+            Some(UserCanisterCreateState::CreateCanister)
+        );
+    }
+
+    #[test]
+    fn test_should_set_create_state() {
+        let principal = Principal::from_text("rwlgt-iiaaa-aaaaa-aaaaa-cai").unwrap();
+        UserCanisterStorage::init_create_state(principal);
+
+        UserCanisterStorage::set_create_state(
+            principal,
+            UserCanisterCreateState::WaitForCreateCanisterSchedule {
+                scheduled_at: "2023-10-01T00:00:00Z".to_string(),
+                request_id: "request_id".to_string(),
+            },
+        );
+
+        assert_eq!(
+            UserCanisterStorage::get_create_state(principal),
+            Some(UserCanisterCreateState::WaitForCreateCanisterSchedule {
+                scheduled_at: "2023-10-01T00:00:00Z".to_string(),
+                request_id: "request_id".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn test_should_set_user_canister() {
+        let principal = Principal::from_text("rwlgt-iiaaa-aaaaa-aaaaa-cai").unwrap();
+        let user_canister = Principal::from_text("rwlgt-iiaaa-aaaaa-aaaaa-cai").unwrap();
+        UserCanisterStorage::set_user_canister(principal, user_canister);
+
+        assert_eq!(
+            UserCanisterStorage::get_user_canister(principal),
+            Some(user_canister)
+        );
+    }
+}

--- a/backend/orchestrator/src/storage/user_canister/create_state.rs
+++ b/backend/orchestrator/src/storage/user_canister/create_state.rs
@@ -1,0 +1,410 @@
+use candid::Principal;
+use did::orbit_station::TimestampRfc3339;
+use ic_stable_structures::Storable;
+use ic_stable_structures::storable::Bound;
+
+use crate::utils::trap;
+
+const OP_CREATE_CANISTER: u8 = 0;
+const OP_WAIT_FOR_CREATE_CANISTER_SCHEDULE: u8 = 1;
+const OP_WAIT_FOR_CREATE_CANISTER_RESULT: u8 = 2;
+const OP_INSTALL_CANISTER: u8 = 3;
+const OP_WAIT_FOR_INSTALL_CANISTER_SCHEDULE: u8 = 4;
+const OP_WAIT_FOR_INSTALL_CANISTER_RESULT: u8 = 5;
+const OP_OK: u8 = 6;
+const OP_FAILED: u8 = 7;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UserCanisterCreateState {
+    /// Send a request to the orbit station to create the user canister.
+    CreateCanister,
+    /// Wait for the orbit station to start scheduled canister creation.
+    /// It can mutate to [`UserCanisterCreateState::WaitForCreateCanisterResult`] when executing.
+    WaitForCreateCanisterSchedule {
+        scheduled_at: TimestampRfc3339,
+        request_id: String,
+    },
+    /// Wait for the create canister operation to finish.
+    /// This state mutates to [`UserCanisterCreateState::WaitForCreateCanisterSchedule`] when scheduled.
+    WaitForCreateCanisterResult { request_id: String },
+    /// Send a request to Install canister on the user canister.
+    InstallCanister { user_canister: Principal },
+    /// Wait for the orbit station to start scheduled canister installation.
+    /// It can mutate to [`UserCanisterCreateState::WaitForInstallCanisterResult`] when executing.
+    WaitForInstallCanisterSchedule {
+        user_canister: Principal,
+        scheduled_at: TimestampRfc3339,
+        request_id: String,
+    },
+    /// Wait for the install canister operation to finish.
+    /// This state mutates to [`UserCanisterCreateState::WaitForInstallCanisterSchedule`] when scheduled.
+    WaitForInstallCanisterResult {
+        user_canister: Principal,
+        request_id: String,
+    },
+    /// The user canister is created and installed.
+    Ok { user_canister: Principal },
+    /// The user canister creation failed.
+    Failed { reason: String },
+}
+
+impl Storable for UserCanisterCreateState {
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 512,
+        is_fixed_size: false,
+    };
+
+    fn from_bytes(bytes: std::borrow::Cow<[u8]>) -> Self {
+        if bytes.is_empty() {
+            trap("Failed to decode UserCanisterCreateState: empty bytes");
+        }
+        // read op code
+        let op_code = bytes[0];
+        match op_code {
+            OP_CREATE_CANISTER => Self::decode_create_canister(),
+            OP_WAIT_FOR_CREATE_CANISTER_SCHEDULE => {
+                Self::decode_wait_for_create_canister_schedule(&bytes[1..])
+            }
+            OP_WAIT_FOR_CREATE_CANISTER_RESULT => {
+                Self::decode_wait_for_create_canister_result(&bytes[1..])
+            }
+            OP_INSTALL_CANISTER => Self::decode_install_canister(&bytes[1..]),
+            OP_WAIT_FOR_INSTALL_CANISTER_SCHEDULE => {
+                Self::decode_wait_for_install_canister_schedule(&bytes[1..])
+            }
+            OP_WAIT_FOR_INSTALL_CANISTER_RESULT => {
+                Self::decode_wait_for_install_canister_result(&bytes[1..])
+            }
+            OP_OK => Self::decode_ok(&bytes[1..]),
+            OP_FAILED => Self::decode_failed(&bytes[1..]),
+            _ => trap("Failed to decode UserCanisterCreateState: invalid operation code"),
+        }
+    }
+
+    fn to_bytes(&self) -> std::borrow::Cow<'_, [u8]> {
+        match self {
+            UserCanisterCreateState::CreateCanister => Self::encode_create_canister().into(),
+            UserCanisterCreateState::WaitForCreateCanisterSchedule {
+                scheduled_at,
+                request_id,
+            } => Self::encode_wait_for_create_canister_schedule(scheduled_at, request_id).into(),
+            UserCanisterCreateState::WaitForCreateCanisterResult { request_id } => {
+                Self::encode_wait_for_create_canister_result(request_id).into()
+            }
+            UserCanisterCreateState::InstallCanister { user_canister } => {
+                Self::encode_install_canister(*user_canister).into()
+            }
+            UserCanisterCreateState::WaitForInstallCanisterSchedule {
+                user_canister,
+                scheduled_at,
+                request_id,
+            } => Self::encode_wait_for_install_canister_schedule(
+                *user_canister,
+                scheduled_at,
+                request_id,
+            )
+            .into(),
+            UserCanisterCreateState::WaitForInstallCanisterResult {
+                user_canister,
+                request_id,
+            } => Self::encode_wait_for_install_canister_result(*user_canister, request_id).into(),
+            UserCanisterCreateState::Ok { user_canister } => Self::encode_ok(*user_canister).into(),
+            UserCanisterCreateState::Failed { reason } => Self::encode_failed(reason).into(),
+        }
+    }
+}
+
+impl UserCanisterCreateState {
+    /// Encode variant for [`UserCanisterCreateState::CreateCanister`].
+    fn encode_create_canister() -> Vec<u8> {
+        vec![OP_CREATE_CANISTER]
+    }
+
+    /// Decode variant for [`UserCanisterCreateState::CreateCanister`].
+    fn decode_create_canister() -> UserCanisterCreateState {
+        UserCanisterCreateState::CreateCanister
+    }
+
+    /// Encode variant for [`UserCanisterCreateState::WaitForCreateCanisterSchedule`].
+    fn encode_wait_for_create_canister_schedule(
+        scheduled_at: &TimestampRfc3339,
+        request_id: &String,
+    ) -> Vec<u8> {
+        let mut bytes = vec![OP_WAIT_FOR_CREATE_CANISTER_SCHEDULE];
+        // write len of time
+        bytes.push(scheduled_at.len() as u8);
+        // write scheduled_at
+        bytes.extend_from_slice(scheduled_at.as_str().as_bytes());
+        // write len of request_id
+        bytes.push(request_id.len() as u8);
+        // write request_id
+        bytes.extend_from_slice(request_id.as_bytes());
+
+        bytes
+    }
+
+    /// Decode variant for [`UserCanisterCreateState::WaitForCreateCanisterSchedule`].
+    fn decode_wait_for_create_canister_schedule(bytes: &[u8]) -> UserCanisterCreateState {
+        let time_len = bytes[0] as usize;
+        let time_bytes = &bytes[1..1 + time_len];
+        let scheduled_at =
+            TimestampRfc3339::from_utf8(time_bytes.to_vec()).expect("failed to parse time");
+        let request_id_len = bytes[1 + time_len] as usize;
+        let request_id_bytes = &bytes[2 + time_len..2 + time_len + request_id_len];
+        let request_id =
+            String::from_utf8(request_id_bytes.to_vec()).expect("failed to parse request_id");
+        UserCanisterCreateState::WaitForCreateCanisterSchedule {
+            scheduled_at,
+            request_id,
+        }
+    }
+
+    /// Encode variant for [`UserCanisterCreateState::WaitForCreateCanisterResult`].
+    fn encode_wait_for_create_canister_result(request_id: &String) -> Vec<u8> {
+        let mut bytes = vec![OP_WAIT_FOR_CREATE_CANISTER_RESULT];
+        // write len of request_id
+        bytes.push(request_id.len() as u8);
+        // write request_id
+        bytes.extend_from_slice(request_id.as_bytes());
+
+        bytes
+    }
+
+    /// Decode variant for [`UserCanisterCreateState::WaitForCreateCanisterResult`].
+    fn decode_wait_for_create_canister_result(bytes: &[u8]) -> UserCanisterCreateState {
+        let request_id_len = bytes[0] as usize;
+        let request_id_bytes = &bytes[1..1 + request_id_len];
+        let request_id =
+            String::from_utf8(request_id_bytes.to_vec()).expect("failed to parse request_id");
+        UserCanisterCreateState::WaitForCreateCanisterResult { request_id }
+    }
+
+    /// Encode variant for [`UserCanisterCreateState::InstallCanister`].
+    fn encode_install_canister(user_canister: Principal) -> Vec<u8> {
+        let mut bytes = vec![OP_INSTALL_CANISTER];
+        // write len of user_canister
+        bytes.push(user_canister.as_slice().len() as u8);
+        // write user_canister
+        bytes.extend_from_slice(user_canister.as_slice());
+
+        bytes
+    }
+
+    /// Decode variant for [`UserCanisterCreateState::InstallCanister`].
+    fn decode_install_canister(bytes: &[u8]) -> UserCanisterCreateState {
+        let user_canister_len = bytes[0] as usize;
+        let user_canister_bytes = &bytes[1..1 + user_canister_len];
+        let user_canister = Principal::from_slice(user_canister_bytes);
+        UserCanisterCreateState::InstallCanister { user_canister }
+    }
+
+    /// Encode variant for [`UserCanisterCreateState::WaitForInstallCanisterSchedule`].
+    fn encode_wait_for_install_canister_schedule(
+        user_canister: Principal,
+        scheduled_at: &TimestampRfc3339,
+        request_id: &String,
+    ) -> Vec<u8> {
+        let mut bytes = vec![OP_WAIT_FOR_INSTALL_CANISTER_SCHEDULE];
+        // write len of user_canister
+        bytes.push(user_canister.as_slice().len() as u8);
+        // write user_canister
+        bytes.extend_from_slice(user_canister.as_slice());
+        // write len of time
+        bytes.push(scheduled_at.len() as u8);
+        // write scheduled_at
+        bytes.extend_from_slice(scheduled_at.as_str().as_bytes());
+        // write len of request_id
+        bytes.push(request_id.len() as u8);
+        // write request_id
+        bytes.extend_from_slice(request_id.as_bytes());
+
+        bytes
+    }
+
+    /// Decode variant for [`UserCanisterCreateState::WaitForInstallCanisterSchedule`].
+    fn decode_wait_for_install_canister_schedule(bytes: &[u8]) -> UserCanisterCreateState {
+        let user_canister_len = bytes[0] as usize;
+        let user_canister_bytes = &bytes[1..1 + user_canister_len];
+        let user_canister = Principal::from_slice(user_canister_bytes);
+        let time_len = bytes[1 + user_canister_len] as usize;
+        let time_bytes = &bytes[2 + user_canister_len..2 + user_canister_len + time_len];
+        let scheduled_at =
+            TimestampRfc3339::from_utf8(time_bytes.to_vec()).expect("failed to parse time");
+        let request_id_len = bytes[2 + user_canister_len + time_len] as usize;
+        let request_id_bytes = &bytes
+            [3 + user_canister_len + time_len..3 + user_canister_len + time_len + request_id_len];
+        let request_id =
+            String::from_utf8(request_id_bytes.to_vec()).expect("failed to parse request_id");
+        UserCanisterCreateState::WaitForInstallCanisterSchedule {
+            user_canister,
+            scheduled_at,
+            request_id,
+        }
+    }
+
+    /// Encode variant for [`UserCanisterCreateState::WaitForInstallCanisterResult`].
+    fn encode_wait_for_install_canister_result(
+        user_canister: Principal,
+        request_id: &String,
+    ) -> Vec<u8> {
+        let mut bytes = vec![OP_WAIT_FOR_INSTALL_CANISTER_RESULT];
+        // write len of user_canister
+        bytes.push(user_canister.as_slice().len() as u8);
+        // write user_canister
+        bytes.extend_from_slice(user_canister.as_slice());
+        // write len of request_id
+        bytes.push(request_id.len() as u8);
+        // write request_id
+        bytes.extend_from_slice(request_id.as_bytes());
+
+        bytes
+    }
+
+    /// Decode variant for [`UserCanisterCreateState::WaitForInstallCanisterResult`].
+    fn decode_wait_for_install_canister_result(bytes: &[u8]) -> UserCanisterCreateState {
+        let user_canister_len = bytes[0] as usize;
+        let user_canister_bytes = &bytes[1..1 + user_canister_len];
+        let user_canister = Principal::from_slice(user_canister_bytes);
+        let request_id_len = bytes[1 + user_canister_len] as usize;
+        let request_id_bytes =
+            &bytes[2 + user_canister_len..2 + user_canister_len + request_id_len];
+        let request_id =
+            String::from_utf8(request_id_bytes.to_vec()).expect("failed to parse request_id");
+        UserCanisterCreateState::WaitForInstallCanisterResult {
+            user_canister,
+            request_id,
+        }
+    }
+
+    /// Encode variant for [`UserCanisterCreateState::Completed`].
+    fn encode_ok(user_canister: Principal) -> Vec<u8> {
+        let mut bytes = vec![OP_OK];
+        // write len of user_canister
+        bytes.push(user_canister.as_slice().len() as u8);
+        // write user_canister
+        bytes.extend_from_slice(user_canister.as_slice());
+
+        bytes
+    }
+
+    /// Decode variant for [`UserCanisterCreateState::Completed`].
+    fn decode_ok(bytes: &[u8]) -> UserCanisterCreateState {
+        println!("bytes: {:?}", bytes);
+        let user_canister_len = bytes[0] as usize;
+        let user_canister_bytes = &bytes[1..1 + user_canister_len];
+        let user_canister = Principal::from_slice(user_canister_bytes);
+        UserCanisterCreateState::Ok { user_canister }
+    }
+
+    /// Encode variant for [`UserCanisterCreateState::Failed`].
+    fn encode_failed(reason: &String) -> Vec<u8> {
+        let mut bytes = vec![];
+        // write op code
+        bytes.push(OP_FAILED);
+        // write len of reason
+        bytes.push(reason.len() as u8);
+        // write reason
+        bytes.extend_from_slice(reason.as_bytes());
+
+        bytes
+    }
+
+    /// Decode variant for [`UserCanisterCreateState::Failed`].
+    fn decode_failed(bytes: &[u8]) -> UserCanisterCreateState {
+        let reason_len = bytes[0] as usize;
+        let reason_bytes = &bytes[1..1 + reason_len];
+        let reason = String::from_utf8(reason_bytes.to_vec()).expect("failed to parse reason");
+        UserCanisterCreateState::Failed { reason }
+    }
+}
+
+#[cfg(test)]
+mod test {
+
+    use super::*;
+
+    #[test]
+    fn test_storable_create_canister_roundtrip() {
+        let state = UserCanisterCreateState::CreateCanister;
+        let bytes = state.to_bytes();
+        let decoded_state = UserCanisterCreateState::from_bytes(bytes);
+        assert_eq!(state, decoded_state);
+    }
+
+    #[test]
+    fn test_storable_wait_for_create_canister_schedule_roundtrip() {
+        let scheduled_at = TimestampRfc3339::from("2023-10-01T00:00:00Z");
+        let request_id = "request_id".to_string();
+        let state = UserCanisterCreateState::WaitForCreateCanisterSchedule {
+            scheduled_at,
+            request_id,
+        };
+        let bytes = state.to_bytes();
+        let decoded_state = UserCanisterCreateState::from_bytes(bytes);
+        assert_eq!(state, decoded_state);
+    }
+
+    #[test]
+    fn test_storable_wait_for_create_canister_result_roundtrip() {
+        let request_id = "request_id".to_string();
+        let state = UserCanisterCreateState::WaitForCreateCanisterResult { request_id };
+        let bytes = state.to_bytes();
+        let decoded_state = UserCanisterCreateState::from_bytes(bytes);
+        assert_eq!(state, decoded_state);
+    }
+
+    #[test]
+    fn test_storable_install_canister_roundtrip() {
+        let user_canister = Principal::from_slice(&[2; 29]);
+        let state = UserCanisterCreateState::InstallCanister { user_canister };
+        let bytes = state.to_bytes();
+        let decoded_state = UserCanisterCreateState::from_bytes(bytes);
+        assert_eq!(state, decoded_state);
+    }
+
+    #[test]
+    fn test_storable_wait_for_install_canister_schedule_roundtrip() {
+        let user_canister = Principal::from_slice(&[2; 29]);
+        let scheduled_at = TimestampRfc3339::from("2023-10-01T00:00:00Z");
+        let request_id = "request_id".to_string();
+        let state = UserCanisterCreateState::WaitForInstallCanisterSchedule {
+            user_canister,
+            scheduled_at,
+            request_id,
+        };
+        let bytes = state.to_bytes();
+        let decoded_state = UserCanisterCreateState::from_bytes(bytes);
+        assert_eq!(state, decoded_state);
+    }
+
+    #[test]
+    fn test_storable_wait_for_install_canister_result_roundtrip() {
+        let user_canister = Principal::from_slice(&[2; 29]);
+        let request_id = "request_id".to_string();
+        let state = UserCanisterCreateState::WaitForInstallCanisterResult {
+            user_canister,
+            request_id,
+        };
+        let bytes = state.to_bytes();
+        let decoded_state = UserCanisterCreateState::from_bytes(bytes);
+        assert_eq!(state, decoded_state);
+    }
+
+    #[test]
+    fn test_storable_completed_roundtrip() {
+        let user_canister = Principal::from_slice(&[2; 29]);
+        let state = UserCanisterCreateState::Ok { user_canister };
+        let bytes = state.to_bytes();
+        let decoded_state = UserCanisterCreateState::from_bytes(bytes);
+        assert_eq!(state, decoded_state);
+    }
+
+    #[test]
+    fn test_storable_failed_roundtrip() {
+        let reason = "failed".to_string();
+        let state = UserCanisterCreateState::Failed { reason };
+        let bytes = state.to_bytes();
+        let decoded_state = UserCanisterCreateState::from_bytes(bytes);
+        assert_eq!(state, decoded_state);
+    }
+}

--- a/backend/orchestrator/src/utils.rs
+++ b/backend/orchestrator/src/utils.rs
@@ -1,4 +1,5 @@
 use candid::Principal;
+use time::OffsetDateTime;
 
 /// Utility functions to trap the canister.
 ///
@@ -24,4 +25,24 @@ pub fn msg_caller() -> Principal {
     } else {
         Principal::from_slice(&[1; 29])
     }
+}
+
+/// Returns current time in nanoseconds
+pub fn time() -> u64 {
+    if cfg!(target_family = "wasm") {
+        ic_cdk::api::time()
+    } else {
+        let time = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("SystemTime before UNIX EPOCH");
+        time.as_nanos() as u64
+    }
+}
+
+/// Returns current datetime
+pub fn datetime() -> OffsetDateTime {
+    let time = time();
+
+    OffsetDateTime::from_unix_timestamp_nanos(time as i128)
+        .unwrap_or_else(|_| trap("Failed to convert time to OffsetDateTime"))
 }

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -8,12 +8,13 @@ license = { workspace = true }
 anyhow = "1"
 candid = { workspace = true }
 did = { path = "../backend/did" }
+flate2 = "1"
 ic-agent = "0.40"
-ic-exports = { git = "https://github.com/bitfinity-network/canister-sdk", package = "ic-exports", tag = "v0.24.x" }
 ic-ledger-types = "0.15.0"
-ic-test-utils = { git = "https://github.com/bitfinity-network/canister-sdk", package = "ic-test-utils", tag = "v0.24.x" }
 ic-utils = "0.40"
-pocket-ic = "7"
+log = "0.4"
+pocket-ic = "9"
+reqwest = { version = "0.12", default-features = false }
 serde = { workspace = true }
 tokio = { version = "1", features = ["full"] }
 
@@ -23,4 +24,4 @@ pretty_assertions = "1"
 [features]
 default = []
 dfx = []
-pocket-ic = ["ic-exports/pocket-ic-tests"]
+pocket-ic = []

--- a/integration-tests/src/pocket_ic.rs
+++ b/integration-tests/src/pocket_ic.rs
@@ -143,7 +143,7 @@ impl PocketIcTestEnv {
         // install orchestrator
         let orchestrator = pic.create_canister_with_settings(Some(admin()), None).await;
         println!("Orchestrator: {orchestrator}",);
-        Self::install_orchestrator(&pic, orchestrator, orbit_station).await;
+        Self::install_orchestrator(&pic, orchestrator, orbit_station, station_admin.clone()).await;
 
         Self {
             backend,
@@ -181,13 +181,17 @@ impl PocketIcTestEnv {
         pic: &PocketIc,
         canister_id: Principal,
         orbit_station: Principal,
+        orbit_station_admin: String,
     ) {
         pic.add_cycles(canister_id, DEFAULT_CYCLES).await;
 
         let wasm_bytes = Self::load_wasm(Canister::Orchestrator);
 
-        let init_arg =
-            Encode!(&OrchestratorInitArgs { orbit_station }).expect("Failed to encode init arg");
+        let init_arg = Encode!(&OrchestratorInitArgs {
+            orbit_station,
+            orbit_station_admin
+        })
+        .expect("Failed to encode init arg");
 
         pic.install_canister(canister_id, wasm_bytes, init_arg, Some(admin()))
             .await;

--- a/integration-tests/src/pocket_ic.rs
+++ b/integration-tests/src/pocket_ic.rs
@@ -1,4 +1,5 @@
 mod cycles;
+mod env;
 mod orchestrator_client;
 
 use std::io::Read as _;
@@ -107,7 +108,7 @@ impl TestEnv for PocketIcTestEnv {
 impl PocketIcTestEnv {
     /// Install the canisters needed for the tests
     pub async fn init() -> Self {
-        let pic = ic_exports::pocket_ic::init_pocket_ic()
+        let pic = env::init_pocket_ic()
             .await
             .with_nns_subnet()
             .with_ii_subnet()

--- a/integration-tests/src/pocket_ic/cycles.rs
+++ b/integration-tests/src/pocket_ic/cycles.rs
@@ -4,8 +4,8 @@ mod icp_ledger;
 
 use std::collections::{HashMap, HashSet};
 
+use super::env::{PocketIc, update_candid_as};
 use candid::{Encode, Principal};
-use ic_exports::pocket_ic::{PocketIc, update_candid_as};
 use ic_ledger_types::{AccountIdentifier, DEFAULT_SUBACCOUNT, Tokens};
 
 use super::PocketIcTestEnv;

--- a/integration-tests/src/pocket_ic/cycles.rs
+++ b/integration-tests/src/pocket_ic/cycles.rs
@@ -4,11 +4,11 @@ mod icp_ledger;
 
 use std::collections::{HashMap, HashSet};
 
-use super::env::{PocketIc, update_candid_as};
 use candid::{Encode, Principal};
 use ic_ledger_types::{AccountIdentifier, DEFAULT_SUBACCOUNT, Tokens};
 
 use super::PocketIcTestEnv;
+use super::env::{PocketIc, update_candid_as};
 use crate::actor::admin;
 use crate::wasm::Canister;
 

--- a/integration-tests/src/pocket_ic/env.rs
+++ b/integration-tests/src/pocket_ic/env.rs
@@ -1,0 +1,155 @@
+use std::io::{Cursor, Read};
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+use std::{env, fs};
+
+use flate2::read::GzDecoder;
+use log::*;
+pub use pocket_ic::PocketIcBuilder;
+pub use pocket_ic::nonblocking::*;
+use tokio::sync::OnceCell;
+
+const POCKET_IC_SERVER_VERSION: &str = "9.0.1";
+const POCKET_IC_BIN: &str = "POCKET_IC_BIN";
+
+/// Returns the pocket-ic client.
+/// If pocket-ic server binary is not present, it downloads it and sets
+/// the `POCKET_IC_BIN` environment variable accordingly.
+/// See: https://crates.io/crates/pocket-ic
+///
+/// The temp directory is used to store the binary.
+///
+/// To use custom server binary, the `POCKET_IC_BIN` environment variable should be set and
+/// point to the binary. Also, the binary should be executable.
+///
+/// It supports only linux and macos.
+pub async fn init_pocket_ic() -> PocketIcBuilder {
+    static INITIALIZATION_STATUS: OnceCell<bool> = OnceCell::const_new();
+
+    let status = INITIALIZATION_STATUS
+        .get_or_init(|| async {
+            if check_custom_pocket_ic_initialized() {
+                // Custom server binary found. Let's use it.
+                return true;
+            };
+
+            if let Some(binary_path) = dbg!(check_default_pocket_ic_binary_exist()) {
+                // Default server binary found. Let's use it.
+                unsafe {
+                    env::set_var(POCKET_IC_BIN, binary_path);
+                }
+                return true;
+            }
+
+            // Server binary not found. Let's download it.
+            let mut target_dir = env::var(POCKET_IC_BIN)
+                .map(PathBuf::from)
+                .unwrap_or_else(|_| default_pocket_ic_server_binary_path());
+
+            target_dir.pop();
+
+            let binary_path = download_binary(target_dir).await;
+            unsafe {
+                env::set_var(POCKET_IC_BIN, binary_path);
+            }
+
+            true
+        })
+        .await;
+
+    if !status {
+        panic!("pocket-ic is not initialized");
+    }
+
+    create_pocket_ic_client()
+}
+
+fn create_pocket_ic_client() -> PocketIcBuilder {
+    // We create a PocketIC instance consisting of the NNS and one application subnet.
+    // With no II subnet, there's no subnet with ECDSA keys.
+    PocketIcBuilder::new()
+        .with_nns_subnet()
+        .with_ii_subnet()
+        .with_application_subnet()
+}
+
+fn default_pocket_ic_server_dir() -> PathBuf {
+    env::temp_dir()
+        .join("pocket-ic-server")
+        .join(POCKET_IC_SERVER_VERSION)
+}
+
+fn default_pocket_ic_server_binary_path() -> PathBuf {
+    default_pocket_ic_server_dir().join("pocket-ic")
+}
+
+fn check_custom_pocket_ic_initialized() -> bool {
+    if let Ok(path) = env::var("POCKET_IC_BIN") {
+        return Path::new(&path).exists();
+    }
+    false
+}
+
+fn check_default_pocket_ic_binary_exist() -> Option<PathBuf> {
+    let path = default_pocket_ic_server_binary_path();
+    path.exists().then_some(path)
+}
+
+async fn download_binary(pocket_ic_dir: PathBuf) -> PathBuf {
+    let platform = match env::consts::OS {
+        "linux" => "linux",
+        "macos" => "darwin",
+        _ => panic!("pocket-ic requires linux or macos"),
+    };
+
+    let download_url = format!(
+        "https://github.com/dfinity/pocketic/releases/download/{POCKET_IC_SERVER_VERSION}/pocket-ic-x86_64-{platform}.gz"
+    );
+
+    // Download file
+    let gz_binary = {
+        info!("downloading pocket-ic server binary from: {download_url}");
+
+        let response = reqwest::Client::builder()
+            .timeout(Duration::from_secs(120))
+            .build()
+            .unwrap()
+            .get(download_url)
+            .send()
+            .await
+            .unwrap();
+
+        response
+            .bytes()
+            .await
+            .expect("pocket-ic server binary should be downloaded correctly")
+    };
+
+    let gz_data_cursor = Cursor::new(gz_binary);
+    let binary_file_path = pocket_ic_dir.join("pocket-ic");
+    fs::create_dir_all(&pocket_ic_dir)
+        .expect("pocket-ic server path directories should be created");
+
+    // unzip file
+    {
+        info!("unzip pocket-ic.gz to [{binary_file_path:?}]");
+
+        let mut tar = GzDecoder::new(gz_data_cursor);
+        let mut temp = vec![];
+        tar.read_to_end(&mut temp)
+            .expect("pocket-ic.gz should be decompressed");
+
+        fs::write(&binary_file_path, temp)
+            .expect("pocket-ic server binary should be written to file");
+
+        #[cfg(target_family = "unix")]
+        {
+            use std::os::unix::prelude::PermissionsExt;
+            let mut perms = std::fs::metadata(&binary_file_path).unwrap().permissions();
+            perms.set_mode(0o770);
+            std::fs::set_permissions(&binary_file_path, perms).unwrap();
+        }
+    }
+
+    binary_file_path
+}

--- a/integration-tests/src/pocket_ic/orchestrator_client.rs
+++ b/integration-tests/src/pocket_ic/orchestrator_client.rs
@@ -1,5 +1,7 @@
 use candid::Principal;
-use did::orchestrator::{GetUsersResponse, PublicKey, SetUserResponse, WhoamiResponse};
+use did::orchestrator::{
+    GetUsersResponse, PublicKey, SetUserResponse, UserCanisterResponse, WhoamiResponse,
+};
 
 use super::PocketIcTestEnv;
 use crate::TestEnv as _;
@@ -50,6 +52,19 @@ impl OrchestratorClient<'_> {
             .query::<WhoamiResponse>(self.pic.orchestrator(), caller, "who_am_i", payload)
             .await
             .expect("Failed to get who am i")
+    }
+
+    pub async fn user_canister(&self, caller: Principal) -> UserCanisterResponse {
+        let payload = candid::encode_args(()).unwrap();
+        self.pic
+            .query::<UserCanisterResponse>(
+                self.pic.orchestrator(),
+                caller,
+                "user_canister",
+                payload,
+            )
+            .await
+            .expect("Failed to get user canister")
     }
 
     pub async fn username_exists(&self, username: String) -> bool {

--- a/integration-tests/tests/pocket_ic/orchestrator.rs
+++ b/integration-tests/tests/pocket_ic/orchestrator.rs
@@ -73,3 +73,23 @@ async fn test_should_not_get_users_if_anonymous() {
 
     env.stop().await;
 }
+
+#[tokio::test]
+async fn test_should_create_user_canister() {
+    let env = PocketIcTestEnv::init().await;
+    let client = OrchestratorClient::from(&env);
+
+    let me = Principal::from_slice(&[1; 29]);
+    let username = "foo".to_string();
+    let public_key = [1; PUBKEY_SIZE];
+
+    // create user canister
+    let response = client.set_user(me, username, public_key).await;
+    assert_eq!(response, SetUserResponse::Ok);
+
+    // wait for user canister to be created
+    let user_canister = client.wait_for_user_canister(me).await;
+    assert_ne!(user_canister, Principal::anonymous());
+
+    env.stop().await;
+}


### PR DESCRIPTION
added the user machine tasks to create user canisters; index user canisters on the orchestrator. Start task when receiveing a set_user request.

We have a state machine which is started with ic_cdk_timers when the user registers with `set_user`.

The state machine has the following steps

```rust
pub enum UserCanisterCreateState {
    /// Send a request to the orbit station to create the user canister.
    CreateCanister,
    /// Wait for the orbit station to start scheduled canister creation.
    /// It can mutate to [`UserCanisterCreateState::WaitForCreateCanisterResult`] when executing.
    WaitForCreateCanisterSchedule {
        scheduled_at: TimestampRfc3339,
        request_id: String,
    },
    /// Wait for the create canister operation to finish.
    /// This state mutates to [`UserCanisterCreateState::WaitForCreateCanisterSchedule`] when scheduled.
    WaitForCreateCanisterResult { request_id: String },
    /// Send a request to Install canister on the user canister.
    InstallCanister { user_canister: Principal },
    /// Wait for the orbit station to start scheduled canister installation.
    /// It can mutate to [`UserCanisterCreateState::WaitForInstallCanisterResult`] when executing.
    WaitForInstallCanisterSchedule {
        user_canister: Principal,
        scheduled_at: TimestampRfc3339,
        request_id: String,
    },
    /// Wait for the install canister operation to finish.
    /// This state mutates to [`UserCanisterCreateState::WaitForInstallCanisterSchedule`] when scheduled.
    WaitForInstallCanisterResult {
        user_canister: Principal,
        request_id: String,
    },
    /// The user canister is created and installed.
    Ok { user_canister: Principal },
    /// The user canister creation failed.
    Failed { reason: String },
}
```

And the flow is already ordered, but is illustrated in the following diagram:

![state-machine drawio](https://github.com/user-attachments/assets/565df1a8-f9b1-449f-89e0-b18a2255b335)

![Untitled Diagram drawio](https://github.com/user-attachments/assets/7f21fc31-3f92-40ba-a91b-936c67885bfd)

Two endpoints have been added:

- user_canister (query): get the user canister state for the caller. If created and running it returns the principal of the user canister
- retry_user_canister_creation (update): in case the user canister failed to create, it triggers the state machine to retry. It fails if the user doesn't exist, if it is anonymous, if the canister already exists or if the canister is already being created.

