### PR TITLE
feat(orchestrator): Index shared files on the Orchestrator Canister

### DIFF
--- a/backend/did/src/orchestrator.rs
+++ b/backend/did/src/orchestrator.rs
@@ -1,3 +1,4 @@
+mod shared_files;
 mod user;
 mod user_canister;
 mod whoami;
@@ -5,6 +6,9 @@ mod whoami;
 use candid::{CandidType, Principal};
 use serde::{Deserialize, Serialize};
 
+pub use self::shared_files::{
+    FileId, RevokeShareFileResponse, ShareFileResponse, SharedFilesResponse,
+};
 pub use self::user::{
     GetUsersResponse, MAX_USERNAME_SIZE, PUBKEY_SIZE, PublicKey, PublicUser, SetUserResponse, User,
 };

--- a/backend/did/src/orchestrator/shared_files.rs
+++ b/backend/did/src/orchestrator/shared_files.rs
@@ -1,0 +1,40 @@
+use std::collections::{HashMap, HashSet};
+
+use candid::{CandidType, Principal};
+use serde::{Deserialize, Serialize};
+
+/// File ID type
+pub type FileId = u64;
+
+/// Result for `share_file` and `share_file_with_users` methods
+#[derive(Debug, Clone, PartialEq, Eq, CandidType, Serialize, Deserialize)]
+pub enum ShareFileResponse {
+    /// The file was shared successfully
+    Ok,
+    /// There is no user with the given principal
+    NoSuchUser(Principal),
+    /// Endpoint was not called by a user canister
+    Unauthorized,
+}
+
+/// Result for `revoke_share_file` methods
+#[derive(Debug, Clone, PartialEq, Eq, CandidType, Serialize, Deserialize)]
+pub enum RevokeShareFileResponse {
+    /// The file was unshared successfully
+    Ok,
+    /// There is no user with the given principal
+    NoSuchUser(Principal),
+    /// Endpoint was not called by a user canister
+    Unauthorized,
+}
+
+/// Result for `shared_files` method
+#[derive(Debug, Clone, PartialEq, Eq, CandidType, Serialize, Deserialize)]
+pub enum SharedFilesResponse {
+    /// List of shared files
+    SharedFiles(HashMap<Principal, HashSet<FileId>>),
+    /// No such user
+    NoSuchUser,
+    /// Anonymous user
+    AnonymousUser,
+}

--- a/backend/orchestrator/src/canister.rs
+++ b/backend/orchestrator/src/canister.rs
@@ -3,11 +3,13 @@ mod create_user;
 use candid::Principal;
 use create_user::CreateUserStateMachine;
 use did::orchestrator::{
-    GetUsersResponse, MAX_USERNAME_SIZE, OrchestratorInitArgs, PublicKey, PublicUser,
-    RetryUserCanisterCreationResponse, SetUserResponse, User, UserCanisterResponse, WhoamiResponse,
+    FileId, GetUsersResponse, MAX_USERNAME_SIZE, OrchestratorInitArgs, PublicKey, PublicUser,
+    RetryUserCanisterCreationResponse, RevokeShareFileResponse, SetUserResponse, ShareFileResponse,
+    SharedFilesResponse, User, UserCanisterResponse, WhoamiResponse,
 };
 
 use crate::storage::config::Config;
+use crate::storage::shared_files::SharedFilesStorage;
 use crate::storage::user_canister::{UserCanisterCreateState, UserCanisterStorage};
 use crate::storage::users::UserStorage;
 use crate::utils::msg_caller;
@@ -44,7 +46,7 @@ impl Canister {
 
     /// Retry the user canister creation for the current caller.
     ///
-    /// Returns:
+    /// # Returns
     ///
     /// - [`RetryUserCanisterCreationResponse::Ok`] if the user canister creation is retried.
     /// - [`RetryUserCanisterCreationResponse::Created`] if the user canister already exists.
@@ -82,7 +84,35 @@ impl Canister {
         }
     }
 
+    /// Revoke the share of a file for a user.
+    ///
+    /// # Returns
+    ///
+    /// - [`RevokeShareFileResponse::Ok`] if the file was unshared successfully.
+    /// - [`RevokeShareFileResponse::NoSuchUser`] if the user doesn't exist.
+    /// - [`RevokeShareFileResponse::Unauthorized`] if the caller is not a user canister.
+    pub fn revoke_share_file(user: Principal, file_id: FileId) -> RevokeShareFileResponse {
+        let user_canister = msg_caller();
+        // check if the caller is a user canister
+        if !UserCanisterStorage::is_user_canister(user_canister) {
+            return RevokeShareFileResponse::Unauthorized;
+        }
+
+        // Revoke share for the user
+        SharedFilesStorage::revoke_share(user, user_canister, file_id);
+
+        RevokeShareFileResponse::Ok
+    }
+
     /// Set a new user in the storage.
+    ///
+    /// # Returns
+    ///
+    /// - [`SetUserResponse::Ok`] if the user was set successfully.
+    /// - [`SetUserResponse::AnonymousCaller`] if the caller is anonymous.
+    /// - [`SetUserResponse::UsernameTooLong`] if the username is too long.
+    /// - [`SetUserResponse::UsernameExists`] if the username already exists.
+    /// - [`SetUserResponse::CallerHasAlreadyAUser`] if the caller already has a user.
     pub fn set_user(username: String, public_key: PublicKey) -> SetUserResponse {
         // Check if the caller is anonymous.
         let caller = msg_caller();
@@ -122,6 +152,68 @@ impl Canister {
         SetUserResponse::Ok
     }
 
+    /// Share a file with a user.
+    ///
+    /// # Returns
+    ///
+    /// - [`ShareFileResponse::Ok`] if the file was shared successfully.
+    /// - [`ShareFileResponse::NoSuchUser`] if the user doesn't exist.
+    /// - [`ShareFileResponse::Unauthorized`] if the caller is not a user canister.
+    pub fn share_file(user: Principal, file_id: FileId) -> ShareFileResponse {
+        Self::share_file_with_users(vec![user], file_id)
+    }
+
+    /// Share a file with many users.
+    ///
+    /// # Returns
+    ///
+    /// - [`ShareFileResponse::Ok`] if the file was shared successfully.
+    /// - [`ShareFileResponse::NoSuchUser`] if the user doesn't exist.
+    /// - [`ShareFileResponse::Unauthorized`] if the caller is not a user canister.
+    pub fn share_file_with_users(users: Vec<Principal>, file_id: FileId) -> ShareFileResponse {
+        let user_canister = msg_caller();
+        // check if the caller is a user canister
+        if !UserCanisterStorage::is_user_canister(user_canister) {
+            return ShareFileResponse::Unauthorized;
+        }
+
+        // check if all the users exist
+        if let Some(no_such_user) = users
+            .iter()
+            .find(|user| UserStorage::get_user(user).is_none())
+        {
+            return ShareFileResponse::NoSuchUser(*no_such_user);
+        }
+
+        // share the file with all the users
+        for user in users {
+            SharedFilesStorage::share_file(user, user_canister, file_id);
+        }
+
+        ShareFileResponse::Ok
+    }
+
+    /// Returns the list of shared files for the caller.
+    ///
+    /// # Returns
+    ///
+    /// - [`SharedFilesResponse::AnonymousUser`] if the caller is anonymous.
+    /// - [`SharedFilesResponse::NoSuchUser`] if the user doesn't exist.
+    /// - [`SharedFilesResponse::SharedFiles`] if the user exists and has shared files.
+    pub fn shared_files() -> SharedFilesResponse {
+        let caller = msg_caller();
+        if caller == Principal::anonymous() {
+            return SharedFilesResponse::AnonymousUser;
+        }
+
+        // check if the user exists
+        if UserStorage::get_user(&caller).is_none() {
+            return SharedFilesResponse::NoSuchUser;
+        }
+
+        SharedFilesResponse::SharedFiles(SharedFilesStorage::get_shared_files(caller))
+    }
+
     /// Checks whether a given username exists in the storage.
     pub fn username_exists(username: String) -> bool {
         UserStorage::username_exists(&username)
@@ -129,10 +221,12 @@ impl Canister {
 
     /// Get user canister information for the current caller.
     ///
-    /// Returns [`UserCanisterResponse::AnonymousCaller`] if the caller is anonymous.
-    /// Returns [`UserCanisterResponse::Ok`] if the user canister is created and ready to use.
-    /// Returns [`UserCanisterResponse::CreationPending`] if the user canister is being created.
-    /// Returns [`UserCanisterResponse::CreationFailed`] if the user canister creation failed.
+    /// # Returns
+    ///
+    /// - [`UserCanisterResponse::AnonymousCaller`] if the caller is anonymous.
+    /// - [`UserCanisterResponse::Ok`] if the user canister is created and ready to use.
+    /// - [`UserCanisterResponse::CreationPending`] if the user canister is being created.
+    /// - [`UserCanisterResponse::CreationFailed`] if the user canister creation failed.
     pub fn user_canister() -> UserCanisterResponse {
         let caller = msg_caller();
         if caller == Principal::anonymous() {
@@ -155,6 +249,11 @@ impl Canister {
     }
 
     /// Get [`WhoamiResponse`] for the current caller.
+    ///
+    /// # Returns
+    ///
+    /// - [`WhoamiResponse::UnknownUser`] if the caller is anonymous or doesn't exist.
+    /// - [`WhoamiResponse::KnownUser`] if the caller exists.
     pub fn whoami() -> WhoamiResponse {
         let caller = msg_caller();
         if caller == Principal::anonymous() {
@@ -170,6 +269,8 @@ impl Canister {
 
 #[cfg(test)]
 mod test {
+
+    use std::collections::HashMap;
 
     use did::orchestrator::User;
 
@@ -406,6 +507,152 @@ mod test {
                 ic_principal: principal,
             })
         );
+    }
+
+    #[test]
+    fn test_should_return_shared_files() {
+        init_canister();
+
+        // setup user
+        let principal = msg_caller();
+        UserStorage::add_user(
+            principal,
+            User {
+                username: "test_user".to_string(),
+                public_key: [1; 32],
+            },
+        );
+
+        // insert shared files
+        let file_id = 1;
+        let user_canister = Principal::from_text("rwlgt-iiaaa-aaaaa-aaaaa-cai").unwrap();
+
+        SharedFilesStorage::share_file(principal, user_canister, file_id);
+
+        let mut expected = HashMap::new();
+        expected.insert(user_canister, vec![file_id].into_iter().collect());
+
+        // get shared files
+        let shared_files = Canister::shared_files();
+        assert_eq!(shared_files, SharedFilesResponse::SharedFiles(expected));
+    }
+
+    #[test]
+    fn test_should_return_error_on_shared_files_unexisting_user() {
+        init_canister();
+
+        // get shared files
+        let shared_files = Canister::shared_files();
+        assert_eq!(shared_files, SharedFilesResponse::NoSuchUser);
+    }
+
+    #[test]
+    fn test_should_revoke_shared_file() {
+        init_canister();
+
+        // insert user canister
+        let user_canister = msg_caller();
+        let user = Principal::from_text("rwlgt-iiaaa-aaaaa-aaaaa-cai").unwrap();
+        UserCanisterStorage::set_user_canister(user, user_canister);
+
+        // revoke share
+        let file_id = 1;
+        SharedFilesStorage::share_file(user, user_canister, file_id);
+        let response = Canister::revoke_share_file(user, file_id);
+        assert_eq!(response, RevokeShareFileResponse::Ok);
+
+        // check if the file is revoked
+        let shared_files = SharedFilesStorage::get_shared_files(user);
+        assert_eq!(shared_files.len(), 0);
+    }
+
+    #[test]
+    fn test_should_not_revoke_shared_file_if_caller_is_not_a_user_canister() {
+        init_canister();
+
+        // insert user canister
+        let user_canister = msg_caller();
+        let user = Principal::from_text("rwlgt-iiaaa-aaaaa-aaaaa-cai").unwrap();
+
+        // revoke share
+        let file_id = 1;
+        SharedFilesStorage::share_file(user, user_canister, file_id);
+        let response = Canister::revoke_share_file(user, file_id);
+        assert_eq!(response, RevokeShareFileResponse::Unauthorized);
+
+        // check if the file is NOT revoked
+        let shared_files = SharedFilesStorage::get_shared_files(user);
+        assert_eq!(shared_files.len(), 1);
+    }
+
+    #[test]
+    fn test_should_share_file() {
+        init_canister();
+
+        // insert user canister
+        let user_canister = msg_caller();
+        let user = Principal::from_text("rwlgt-iiaaa-aaaaa-aaaaa-cai").unwrap();
+
+        // set user canister
+        UserCanisterStorage::set_user_canister(user, user_canister);
+
+        // create user
+        let alice = Principal::from_text("rwlgt-iiaaa-aaaaa-aaaaa-cai").unwrap();
+        UserStorage::add_user(
+            alice,
+            User {
+                username: "test_user".to_string(),
+                public_key: [1; 32],
+            },
+        );
+
+        // share file
+        let file_id = 1;
+        let response = Canister::share_file(alice, file_id);
+        assert_eq!(response, ShareFileResponse::Ok);
+
+        // check if the file is shared
+        let shared_files = SharedFilesStorage::get_shared_files(alice);
+        assert_eq!(shared_files.len(), 1);
+    }
+
+    #[test]
+    fn test_should_not_share_if_not_called_by_user_canister() {
+        init_canister();
+
+        let user = Principal::from_text("rwlgt-iiaaa-aaaaa-aaaaa-cai").unwrap();
+
+        // share file
+        let file_id = 1;
+        let response = Canister::share_file(user, file_id);
+        assert_eq!(response, ShareFileResponse::Unauthorized);
+
+        // check if the file is NOT shared
+        let shared_files = SharedFilesStorage::get_shared_files(user);
+        assert_eq!(shared_files.len(), 0);
+    }
+
+    #[test]
+    fn test_should_not_share_if_user_does_not_exist() {
+        init_canister();
+
+        // insert user canister
+        let user_canister = msg_caller();
+        let user = Principal::from_text("rwlgt-iiaaa-aaaaa-aaaaa-cai").unwrap();
+
+        // set user canister
+        UserCanisterStorage::set_user_canister(user, user_canister);
+
+        let alice = Principal::from_text("rwlgt-iiaaa-aaaaa-aaaaa-cai").unwrap();
+
+        // share file
+        let file_id = 1;
+        let response = Canister::share_file(alice, file_id);
+        assert_eq!(response, ShareFileResponse::NoSuchUser(alice));
+
+        // check if the file is NOT shared
+        let shared_files = SharedFilesStorage::get_shared_files(alice);
+        assert_eq!(shared_files.len(), 0);
     }
 
     fn init_canister() {

--- a/backend/orchestrator/src/lib.rs
+++ b/backend/orchestrator/src/lib.rs
@@ -5,8 +5,9 @@ mod utils;
 
 use candid::Principal;
 use did::orchestrator::{
-    GetUsersResponse, OrchestratorInitArgs, PublicKey, RetryUserCanisterCreationResponse,
-    SetUserResponse, UserCanisterResponse, WhoamiResponse,
+    FileId, GetUsersResponse, OrchestratorInitArgs, PublicKey, RetryUserCanisterCreationResponse,
+    RevokeShareFileResponse, SetUserResponse, ShareFileResponse, SharedFilesResponse,
+    UserCanisterResponse, WhoamiResponse,
 };
 use ic_cdk_macros::{init, query, update};
 
@@ -34,8 +35,28 @@ pub fn retry_user_canister_creation() -> RetryUserCanisterCreationResponse {
 }
 
 #[update]
+pub fn revoke_share_file(user: Principal, file_id: FileId) -> RevokeShareFileResponse {
+    Canister::revoke_share_file(user, file_id)
+}
+
+#[update]
 pub fn set_user(username: String, public_key: PublicKey) -> SetUserResponse {
     Canister::set_user(username, public_key)
+}
+
+#[update]
+pub fn share_file(user: Principal, file_id: FileId) -> ShareFileResponse {
+    Canister::share_file(user, file_id)
+}
+
+#[update]
+pub fn share_file_with_users(users: Vec<Principal>, file_id: FileId) -> ShareFileResponse {
+    Canister::share_file_with_users(users, file_id)
+}
+
+#[query]
+pub fn shared_files() -> SharedFilesResponse {
+    Canister::shared_files()
 }
 
 #[query]

--- a/backend/orchestrator/src/storage.rs
+++ b/backend/orchestrator/src/storage.rs
@@ -1,4 +1,5 @@
 pub mod config;
+pub mod shared_files;
 pub mod user_canister;
 pub mod users;
 

--- a/backend/orchestrator/src/storage/memory.rs
+++ b/backend/orchestrator/src/storage/memory.rs
@@ -8,7 +8,10 @@ pub const USER_STORAGE_MEMORY_ID: MemoryId = MemoryId::new(10);
 pub const USERNAMES_MEMORY_ID: MemoryId = MemoryId::new(11);
 
 pub const USER_CANISTERS_MEMORY_ID: MemoryId = MemoryId::new(20);
-pub const USER_CANISTER_CREATE_STATES_MEMORY_ID: MemoryId = MemoryId::new(21);
+pub const USER_CANISTERS_INDEX_MEMORY_ID: MemoryId = MemoryId::new(21);
+pub const USER_CANISTER_CREATE_STATES_MEMORY_ID: MemoryId = MemoryId::new(22);
+
+pub const SHARED_FILES_MEMORY_ID: MemoryId = MemoryId::new(30);
 
 thread_local! {
     /// Memory manager

--- a/backend/orchestrator/src/storage/shared_files.rs
+++ b/backend/orchestrator/src/storage/shared_files.rs
@@ -1,0 +1,142 @@
+mod user_shared_files;
+
+use std::cell::RefCell;
+use std::collections::{HashMap, HashSet};
+
+use candid::Principal;
+use did::StorablePrincipal;
+use did::orchestrator::FileId;
+use ic_stable_structures::memory_manager::VirtualMemory;
+use ic_stable_structures::{DefaultMemoryImpl, StableBTreeMap};
+
+use self::user_shared_files::UserSharedFiles;
+use crate::storage::memory::{MEMORY_MANAGER, SHARED_FILES_MEMORY_ID};
+
+thread_local! {
+    /// Shared files. Maps users to their shared files, grouped by the user canister.
+    static SHARED_FILES: RefCell<StableBTreeMap<StorablePrincipal, UserSharedFiles, VirtualMemory<DefaultMemoryImpl>>> =
+        RefCell::new(StableBTreeMap::new(MEMORY_MANAGER.with(|mm| mm.get(SHARED_FILES_MEMORY_ID)))
+    );
+}
+
+/// Accessor for Storage for shared files.
+///
+/// Maps users to their shared files, grouped by the user canister.
+pub struct SharedFilesStorage;
+
+impl SharedFilesStorage {
+    /// Share a file with a user for the provided user canister.
+    ///
+    /// Marks the file as shared for the user canister
+    pub fn share_file(user: Principal, user_canister: Principal, file_id: FileId) {
+        SHARED_FILES.with_borrow_mut(|shared_files| {
+            let storable_user = StorablePrincipal::from(user);
+            if !shared_files.contains_key(&storable_user) {
+                shared_files.insert(storable_user, UserSharedFiles::default());
+            }
+
+            let mut user_shared_files = shared_files
+                .get(&storable_user)
+                .expect("user shared files must exist at this point");
+
+            user_shared_files.insert_file(user_canister, file_id);
+
+            shared_files.insert(storable_user, user_shared_files);
+        })
+    }
+
+    /// Revoke a file share for a user for the provided user canister.
+    pub fn revoke_share(user: Principal, user_canister: Principal, file_id: FileId) {
+        SHARED_FILES.with_borrow_mut(|shared_files| {
+            let storable_user = StorablePrincipal::from(user);
+            if !shared_files.contains_key(&storable_user) {
+                return;
+            }
+
+            let mut user_shared_files = shared_files
+                .get(&storable_user)
+                .expect("user shared files must exist at this point");
+
+            user_shared_files.remove_file(user_canister, file_id);
+
+            // If the user has no more files, remove the user from the map.
+            if user_shared_files.is_empty() {
+                shared_files.remove(&storable_user);
+            } else {
+                shared_files.insert(storable_user, user_shared_files);
+            }
+        })
+    }
+
+    /// For a user, get the list of file IDs shared for each user canister.
+    pub fn get_shared_files(user: Principal) -> HashMap<Principal, HashSet<FileId>> {
+        SHARED_FILES.with_borrow(|shared_files| {
+            let storable_user = StorablePrincipal::from(user);
+
+            shared_files
+                .get(&storable_user)
+                .map(|user_shared_files| user_shared_files.get_files())
+                .unwrap_or_default()
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+
+    use super::*;
+
+    #[test]
+    fn test_should_insert_and_get_files_for_users() {
+        let alice = Principal::from_slice(&[1; 29]);
+        let bob = Principal::from_slice(&[2; 29]);
+
+        let user_canister_a = Principal::from_slice(&[3; 29]);
+        let user_canister_b = Principal::from_slice(&[4; 29]);
+
+        // insert
+        SharedFilesStorage::share_file(alice, user_canister_a, 1);
+        SharedFilesStorage::share_file(alice, user_canister_b, 2);
+        SharedFilesStorage::share_file(bob, user_canister_a, 1);
+
+        // check
+        let alice_files = SharedFilesStorage::get_shared_files(alice);
+        assert_eq!(alice_files.len(), 2);
+        assert!(alice_files.contains_key(&user_canister_a));
+        assert!(alice_files.contains_key(&user_canister_b));
+        assert!(alice_files[&user_canister_a].contains(&1));
+        assert!(alice_files[&user_canister_b].contains(&2));
+
+        let bob_files = SharedFilesStorage::get_shared_files(bob);
+        assert_eq!(bob_files.len(), 1);
+        assert!(bob_files.contains_key(&user_canister_a));
+        assert!(bob_files[&user_canister_a].contains(&1));
+    }
+
+    #[test]
+    fn test_should_revoke_file() {
+        let alice = Principal::from_slice(&[1; 29]);
+        let user_canister_a = Principal::from_slice(&[3; 29]);
+
+        // insert
+        SharedFilesStorage::share_file(alice, user_canister_a, 1);
+        SharedFilesStorage::share_file(alice, user_canister_a, 2);
+
+        // revoke
+        SharedFilesStorage::revoke_share(alice, user_canister_a, 1);
+
+        // check
+        let alice_files = SharedFilesStorage::get_shared_files(alice);
+        assert_eq!(alice_files.len(), 1);
+        assert!(alice_files.contains_key(&user_canister_a));
+        assert!(!alice_files[&user_canister_a].contains(&1));
+        assert!(alice_files[&user_canister_a].contains(&2));
+
+        // revoke the last file
+        SharedFilesStorage::revoke_share(alice, user_canister_a, 2);
+
+        // check
+        let alice_files = SharedFilesStorage::get_shared_files(alice);
+        assert_eq!(alice_files.len(), 0);
+    }
+}

--- a/backend/orchestrator/src/storage/shared_files/user_shared_files.rs
+++ b/backend/orchestrator/src/storage/shared_files/user_shared_files.rs
@@ -1,0 +1,223 @@
+use std::borrow::Cow;
+use std::collections::{HashMap, HashSet};
+
+use candid::Principal;
+use did::orchestrator::FileId;
+use ic_stable_structures::Storable;
+use ic_stable_structures::storable::Bound;
+
+/// Map of shared files for each user.
+///
+/// Association between the user canister and the list of file IDs shared for that user.
+///
+/// ## Encoding
+///
+/// - The first 8 bytes are the length of the map.
+/// - For each user canister:
+///  - 1 byte: length of the user canister ID.
+///  - N bytes: user canister ID.
+///  - 8 bytes: length of the file ID list.
+///  - For each file ID:
+///    - 8 byte: file ID
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct UserSharedFiles(HashMap<Principal, HashSet<FileId>>);
+
+impl UserSharedFiles {
+    /// Returns whether the map is empty.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Insert a file ID into the list of shared files for a user.
+    pub fn insert_file(&mut self, user: Principal, file_id: FileId) {
+        self.0.entry(user).or_default().insert(file_id);
+    }
+
+    /// Get the list of file IDs shared for a user.
+    ///
+    /// If the map is empty after removing the file, the user entry is removed from the map.
+    pub fn remove_file(&mut self, user: Principal, file_id: FileId) {
+        if let Some(files) = self.0.get_mut(&user) {
+            files.remove(&file_id);
+            if files.is_empty() {
+                self.0.remove(&user);
+            }
+        }
+    }
+
+    /// Get the list of file IDs shared for each user canister.
+    pub fn get_files(&self) -> HashMap<Principal, HashSet<FileId>> {
+        let mut files = HashMap::new();
+        for (user, file_ids) in &self.0 {
+            files.insert(*user, file_ids.clone());
+        }
+
+        files
+    }
+}
+
+impl Storable for UserSharedFiles {
+    const BOUND: Bound = Bound::Unbounded;
+
+    fn to_bytes(&self) -> Cow<[u8]> {
+        let mut bytes = vec![];
+        // write the number of user canisters
+        let len = self.0.len() as u64;
+        bytes.extend_from_slice(&len.to_le_bytes());
+
+        // iterate over the user canisters
+        for (user_canister, file_ids) in &self.0 {
+            let user_canister_bytes = user_canister.as_slice();
+            // write the length of the user canister ID
+            bytes.push(user_canister_bytes.len() as u8);
+            // write the user canister ID
+            bytes.extend_from_slice(user_canister_bytes);
+
+            // write the number of file IDs
+            let file_ids_len = file_ids.len() as u64;
+            bytes.extend_from_slice(&file_ids_len.to_le_bytes());
+            // write the file IDs
+            for file_id in file_ids {
+                bytes.extend_from_slice(&file_id.to_le_bytes());
+            }
+        }
+
+        bytes.into()
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        // read the number of user canisters
+        let map_len =
+            u64::from_le_bytes(bytes[0..8].try_into().expect("invalid user map len")) as usize;
+        let mut offset = 8;
+        // allocate map
+        let mut map = HashMap::with_capacity(map_len);
+        // iterate over the user canisters
+        for _ in 0..map_len {
+            // read the length of the user canister ID
+            let user_canister_len = bytes[offset] as usize;
+            offset += 1;
+            // read the user canister ID
+            let user_canister = Principal::from_slice(&bytes[offset..offset + user_canister_len]);
+            offset += user_canister_len;
+
+            // read the number of file IDs
+            let file_ids_len = u64::from_le_bytes(
+                bytes[offset..offset + 8]
+                    .try_into()
+                    .expect("Invalid file IDs length"),
+            ) as usize;
+            offset += 8;
+            // allocate file IDs
+            let mut file_ids = HashSet::with_capacity(file_ids_len);
+            // read the file IDs
+            for _ in 0..file_ids_len {
+                let file_id = FileId::from_le_bytes(
+                    bytes[offset..offset + 8]
+                        .try_into()
+                        .expect("Invalid file ID length"),
+                );
+                offset += 8;
+                file_ids.insert(file_id);
+            }
+
+            // insert the user canister and file IDs into the map
+            map.insert(user_canister, file_ids);
+        }
+
+        Self(map)
+    }
+}
+
+#[cfg(test)]
+mod test {
+
+    use super::*;
+
+    #[test]
+    fn test_should_insert_file() {
+        let mut user_shared_files = UserSharedFiles::default();
+        let user = Principal::from_slice(&[1; 29]);
+        let file_id = 1;
+
+        user_shared_files.insert_file(user, file_id);
+
+        assert_eq!(user_shared_files.0.len(), 1);
+        assert!(user_shared_files.0.contains_key(&user));
+        assert!(user_shared_files.0[&user].contains(&file_id));
+
+        // insert another file ID
+        user_shared_files.insert_file(user, 2);
+        assert_eq!(user_shared_files.0.len(), 1);
+        assert!(user_shared_files.0.contains_key(&user));
+        assert!(user_shared_files.0[&user].contains(&file_id));
+        assert!(user_shared_files.0[&user].contains(&2));
+    }
+
+    #[test]
+    fn test_should_remove_file() {
+        let mut user_shared_files = UserSharedFiles::default();
+        let user = Principal::from_slice(&[1; 29]);
+        let file_id = 1;
+
+        user_shared_files.insert_file(user, file_id);
+        user_shared_files.remove_file(user, file_id);
+
+        // check that user canister is removed
+        assert!(!user_shared_files.0.contains_key(&user));
+
+        // insert two
+        user_shared_files.insert_file(user, file_id);
+        user_shared_files.insert_file(user, 2);
+
+        // remove 1
+        user_shared_files.remove_file(user, file_id);
+        // check that user canister is still present
+        assert!(user_shared_files.0.contains_key(&user));
+        // check that file ID 1 is removed
+        assert!(!user_shared_files.0[&user].contains(&file_id));
+        // check that file ID 2 is still present
+        assert!(user_shared_files.0[&user].contains(&2));
+    }
+
+    #[test]
+    fn test_should_get_files() {
+        let mut user_shared_files = UserSharedFiles::default();
+        let user = Principal::from_slice(&[1; 29]);
+        let user_2 = Principal::from_slice(&[2; 29]);
+
+        user_shared_files.insert_file(user, 1);
+        user_shared_files.insert_file(user, 2);
+
+        user_shared_files.insert_file(user_2, 1);
+        user_shared_files.insert_file(user_2, 2);
+
+        let user_canisters_shares = user_shared_files.get_files();
+
+        assert_eq!(user_canisters_shares.len(), 2);
+        assert!(user_canisters_shares.contains_key(&user));
+        assert!(user_canisters_shares[&user].contains(&1));
+        assert!(user_canisters_shares[&user].contains(&2));
+
+        assert!(user_canisters_shares.contains_key(&user_2));
+        assert!(user_canisters_shares[&user_2].contains(&1));
+        assert!(user_canisters_shares[&user_2].contains(&2));
+    }
+
+    #[test]
+    fn test_storable_roundtrip() {
+        let mut user_shared_files = UserSharedFiles::default();
+        let user = Principal::from_slice(&[1; 29]);
+        let user_2 = Principal::from_slice(&[2; 29]);
+
+        user_shared_files.insert_file(user, 1);
+        user_shared_files.insert_file(user, 2);
+
+        user_shared_files.insert_file(user_2, 1);
+        user_shared_files.insert_file(user_2, 2);
+
+        let bytes = user_shared_files.to_bytes();
+        let decoded = UserSharedFiles::from_bytes(bytes);
+        assert_eq!(decoded, user_shared_files);
+    }
+}

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -4,6 +4,7 @@ use serde::de::DeserializeOwned;
 pub mod actor;
 #[cfg(feature = "pocket-ic")]
 mod pocket_ic;
+#[cfg(feature = "pocket-ic")]
 mod wasm;
 
 #[cfg(feature = "pocket-ic")]

--- a/integration-tests/src/pocket_ic/orchestrator_client.rs
+++ b/integration-tests/src/pocket_ic/orchestrator_client.rs
@@ -2,7 +2,8 @@ use std::time::Duration;
 
 use candid::Principal;
 use did::orchestrator::{
-    GetUsersResponse, PublicKey, SetUserResponse, UserCanisterResponse, WhoamiResponse,
+    GetUsersResponse, PublicKey, SetUserResponse, SharedFilesResponse, UserCanisterResponse,
+    WhoamiResponse,
 };
 
 use super::PocketIcTestEnv;
@@ -46,6 +47,14 @@ impl OrchestratorClient<'_> {
             .update::<SetUserResponse>(self.pic.orchestrator(), caller, "set_user", payload)
             .await
             .expect("Failed to set user")
+    }
+
+    pub async fn shared_files(&self, caller: Principal) -> SharedFilesResponse {
+        let payload = candid::encode_args(()).unwrap();
+        self.pic
+            .query::<SharedFilesResponse>(self.pic.orchestrator(), caller, "shared_files", payload)
+            .await
+            .expect("Failed to get shared files")
     }
 
     pub async fn who_am_i(&self, caller: Principal) -> WhoamiResponse {

--- a/integration-tests/tests/pocket_ic/orchestrator.rs
+++ b/integration-tests/tests/pocket_ic/orchestrator.rs
@@ -1,6 +1,6 @@
 use candid::Principal;
 use did::orchestrator::{
-    GetUsersResponse, PUBKEY_SIZE, PublicUser, SetUserResponse, WhoamiResponse,
+    GetUsersResponse, PUBKEY_SIZE, PublicUser, SetUserResponse, SharedFilesResponse, WhoamiResponse,
 };
 use integration_tests::{OrchestratorClient, PocketIcTestEnv, TestEnv};
 
@@ -90,6 +90,17 @@ async fn test_should_create_user_canister() {
     // wait for user canister to be created
     let user_canister = client.wait_for_user_canister(me).await;
     assert_ne!(user_canister, Principal::anonymous());
+
+    env.stop().await;
+}
+
+#[tokio::test]
+async fn test_should_not_return_shared_files_if_anonymous() {
+    let env = PocketIcTestEnv::init().await;
+    let client = OrchestratorClient::from(&env);
+
+    let shared_files = client.shared_files(Principal::anonymous()).await;
+    assert_eq!(shared_files, SharedFilesResponse::AnonymousUser);
 
     env.stop().await;
 }


### PR DESCRIPTION
Added endpoints and storage to associate for each user a map between a user canister and the files shared with him