### PR TITLE
fix: Safe share/revoke behaviour on user canister

### DIFF
--- a/backend/did/src/user_canister/file.rs
+++ b/backend/did/src/user_canister/file.rs
@@ -82,6 +82,7 @@ pub enum UploadFileError {
 /// File upload response
 /// - `pending_error`: The file is pending upload.
 /// - `permission_error`: The file is not shared with the user.
+/// - `file_not_found`: The file is not found.
 /// - `ok`: The file is uploaded successfully.
 #[derive(CandidType, Serialize, Deserialize, Debug, PartialEq)]
 pub enum FileSharingResponse {
@@ -89,6 +90,8 @@ pub enum FileSharingResponse {
     PendingError,
     #[serde(rename = "permission_error")]
     PermissionError,
+    #[serde(rename = "file_not_found")]
+    FileNotFound,
     #[serde(rename = "ok")]
     Ok,
 }

--- a/backend/user_canister/src/canister.rs
+++ b/backend/user_canister/src/canister.rs
@@ -243,7 +243,8 @@ impl Canister {
             trap("Only the owner can share a file");
         }
 
-        match share::CanisterShareFile::share_file(user_id, file_id, file_key_encrypted_for_user) {
+        // check whether we can share the file
+        match share::CanisterShareFile::check_shareable(file_id) {
             FileSharingResponse::Ok => {}
             err => {
                 return err;
@@ -268,7 +269,7 @@ impl Canister {
             }
         }
 
-        FileSharingResponse::Ok
+        share::CanisterShareFile::share_file(user_id, file_id, file_key_encrypted_for_user)
     }
 
     /// Share file with users
@@ -282,19 +283,18 @@ impl Canister {
             trap("Only the owner can share a file");
         }
 
-        for (user, decryption_key) in users.iter().zip(file_key_encrypted_for_user.iter()) {
-            match share::CanisterShareFile::share_file(*user, file_id, *decryption_key) {
-                FileSharingResponse::Ok => {}
-                err => {
-                    trap(format!("Error sharing file: {:?}", err).as_str());
-                }
+        // check whether we can share the file
+        match share::CanisterShareFile::check_shareable(file_id) {
+            FileSharingResponse::Ok => {}
+            err => {
+                trap(format!("Error sharing file: {:?}", err).as_str());
             }
         }
 
         // Index files on the orchestrator
         if cfg!(target_family = "wasm") {
             match OrchestratorClient::from(Config::get_orchestrator())
-                .share_file_with_users(users, file_id)
+                .share_file_with_users(&users, file_id)
                 .await
             {
                 Err(err) => {
@@ -308,6 +308,16 @@ impl Canister {
                 }
             }
         }
+
+        // commit changes to the canister storage
+        for (user, decryption_key) in users.iter().zip(file_key_encrypted_for_user.iter()) {
+            match share::CanisterShareFile::share_file(*user, file_id, *decryption_key) {
+                FileSharingResponse::Ok => {}
+                err => {
+                    trap(format!("Error sharing file: {:?}", err).as_str());
+                }
+            }
+        }
     }
 
     /// Revoke file sharing
@@ -316,22 +326,12 @@ impl Canister {
             trap("Only the owner can revoke file sharing");
         }
 
-        // remove file from user shares
-        FileSharesStorage::revoke(&user_id, &file_id);
-        // remove user from file shares
-        let mut file = FileDataStorage::get_file(&file_id).unwrap();
-        match &mut file.content {
-            FileContent::Uploaded { shared_keys, .. } => {
-                shared_keys.remove(&user_id);
-            }
-            FileContent::PartiallyUploaded { shared_keys, .. } => {
-                shared_keys.remove(&user_id);
-            }
-            _ => {}
-        }
-        // persist file
-        FileDataStorage::set_file(&file_id, file);
+        // get file first checking if it exists
+        let Some(mut file) = FileDataStorage::get_file(&file_id) else {
+            trap("File not found");
+        };
 
+        // first call the orchestrator to revoke the file, since this can fail
         if cfg!(target_family = "wasm") {
             // Revoke files on the orchestrator
             if let Err(err) = OrchestratorClient::from(Config::get_orchestrator())
@@ -341,6 +341,23 @@ impl Canister {
                 trap(format!("Error revoking shared file on orchestrator: {:?}", err).as_str());
             }
         }
+
+        // remove user from file shares (cannot fail)
+        match &mut file.content {
+            FileContent::Uploaded { shared_keys, .. } => {
+                shared_keys.remove(&user_id);
+            }
+            FileContent::PartiallyUploaded { shared_keys, .. } => {
+                shared_keys.remove(&user_id);
+            }
+            _ => {}
+        }
+
+        // persist file (cannot fail)
+        FileDataStorage::set_file(&file_id, file);
+
+        // remove file from user shares (cannot fail)
+        FileSharesStorage::revoke(&user_id, &file_id);
     }
 
     /// Download file

--- a/backend/user_canister/src/client/orchestrator.rs
+++ b/backend/user_canister/src/client/orchestrator.rs
@@ -52,7 +52,7 @@ impl OrchestratorClient {
     /// Share file with multiple users.
     pub async fn share_file_with_users(
         &self,
-        users: Vec<Principal>,
+        users: &[Principal],
         file_id: FileId,
     ) -> CallResult<ShareFileResponse> {
         Call::unbounded_wait(self.principal, "share_file_with_users")


### PR DESCRIPTION
We should ensure that we avoid inconsistent state when dealing with inter canister calls, so we need to first ensure that everything on the local canister cannot fail, mutate the other canister and finally commit changes without failingt